### PR TITLE
add manual cross tests for membership

### DIFF
--- a/test_membership.apln
+++ b/test_membership.apln
@@ -26,10 +26,10 @@
                             r,←assert (((≢data)⍴1) ≡ (data∊data2)) 'tcross0' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
                             :Continue
                         :EndIf
-                        r,←assert (((≢data)⍴0) ≡ (data∊data2)) 'tcross1' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
-                        r,←assert (((≢data2)⍴0) ≡ (data2∊data)) 'tcross2' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
-                        r,←assert (((≢data)⍴1) ≡ (data∊data,data2)) 'tcross3' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
-                        r,←assert ((((≢data)⍴1),((≢data2)⍴0))≡((data,data2)∊data)) 'tcross4' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
+                        r,←assert (((≢data)⍴0) ≡ (data∊data2)) 'tcross1' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2)) ⍝ no match, all return 0
+                        r,←assert (((≢data2)⍴0) ≡ (data2∊data)) 'tcross2' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2)) ⍝ no match, all return 0
+                        r,←assert (((≢data)⍴1) ≡ (data∊data,data2)) 'tcross3' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2)) ⍝ first data match, returns 1
+                        r,←assert ((((≢data)⍴1),((≢data2)⍴0))≡((data,data2)∊data)) 'tcross4' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2)) ⍝ data match, data2 no match
                     :EndFor
                     r,←assert ((data[?≢data])∊data) 't1' ('for ⎕DR', ⎕DR data)                  ⍝ random element is found
                     r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' ('for ⎕DR', ⎕DR data)  ⍝ All elements return 0 except last
@@ -49,6 +49,15 @@
                     r,←assert (0∊0) 'tb1' ('for ⎕DR', ⎕DR data)
                     r,←assert (~0∊1) 'tb2' ('for ⎕DR', ⎕DR data)
                     r,←assert (1 1≡bool∊bool) 'tb3' ('for ⎕DR', ⎕DR bool)
+                    :For data2 :In i1 i2 i3 char1 char2 char3 ptr dbl fl cmplx ⍝ bool requires separate cross tests because of overlap with i1
+                        :If (83≠type←⎕DR data2)
+                                r,←assert (((≢bool)⍴0) ≡ (bool∊data2)) 'tcrossBool' ('for ⎕DR', (⎕DR bool), 'and', (⎕DR data2)) ⍝ All elements return 0
+                                r,←assert (((≢data2)⍴0) ≡ (data2∊bool)) 'tcrossBool' ('for ⎕DR', (⎕DR bool), 'and', (⎕DR data2)) ⍝ All elements return 0
+                            :Else
+                                r,←assert (((≢bool)⍴1) ≡ (bool∊data2)) 'tcrossBool' ('for ⎕DR', (⎕DR bool), 'and', (⎕DR data2)) ⍝ All elements return 1
+                                r,←assert (((⊣,(⌽⊣))((1↓((≢i1)÷2)⍴0),1)) ≡ (data2∊bool)) 'tcrossBool' ('for ⎕DR', (⎕DR bool), 'and', (⎕DR data2)) ⍝ overlaping 0 1 returns 1
+                        :EndIf
+                    :EndFor
                 :EndIf
             :EndFor
         ∇

--- a/test_membership.apln
+++ b/test_membership.apln
@@ -8,28 +8,29 @@
             bool←0 1                                ⍝ 11: 1 bit Boolean type arrays
             i1←¯60+⍳120                             ⍝ 83: 8 bits signed integer
             char1←⎕UCS ⍳255                         ⍝ 80: 8 bits character
-            char2←⎕UCS ⍳10000                       ⍝ 160: 16 bits character
+            char2←⎕UCS (256+⍳10000)                 ⍝ 160: 16 bits character
             i2←{⍵,-⍵}10000+⍳1000                    ⍝ 163: 16 bits signed integer
-            char3←⎕UCS ⍳100000                      ⍝ 320: 32 bits character
+            char3←⎕UCS (10256+⍳100000)              ⍝ 320: 32 bits character
             i3←{⍵,-⍵}100000+⍳1000                   ⍝ 323: 32 bits signed  integer
             ptr←2,/⎕A                               ⍝ 326: Pointer (32-bit or 64-bit as appropriate)
             dbl←{⍵,-⍵}i3+0.1                        ⍝ 645: 64 bits Floating
             ⎕FR←1287 ⋄ fl←{⍵,-⍵}i3+0.01 ⋄ ⎕FR←645   ⍝ 1287: 128 bits Decimal
             cmplx←{⍵,-⍵}(0J1×⍳10000)+⌽⍳10000       ⍝ 1289: 128 bits Complex
 
-            CustomMem←{
-                w←,⍵
-                n←(≢w)+1
-                n>w⍳⍺
-            }
-
             r←⍬
             :For data :In bool i1 i2 i3 char1 char2 char3 ptr dbl fl cmplx
-                ⍝ testing the datatype with all other data types using a custom function
-                :For data2 :In bool i1 i2 i3 char1 char2 char3 ptr dbl fl cmplx                  
-                    r,←assert ((data CustomMem data2)≡(data ∊ data2)) 'tcross' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
-                :EndFor
                 :If 11≠type←⎕DR data
+                    ⍝ Cross DR testing
+                    :For data2 :In i1 i2 i3 char1 char2 char3 ptr dbl fl cmplx
+                        :If (data≡data2)
+                            r,←assert (((≢data)⍴1) ≡ (data∊data2)) 'tcross0' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
+                            :Continue
+                        :EndIf
+                        r,←assert (((≢data)⍴0) ≡ (data∊data2)) 'tcross1' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
+                        r,←assert (((≢data2)⍴0) ≡ (data2∊data)) 'tcross2' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
+                        r,←assert (((≢data)⍴1) ≡ (data∊data,data2)) 'tcross3' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
+                        r,←assert ((((≢data)⍴1),((≢data2)⍴0))≡((data,data2)∊data)) 'tcross4' ('for ⎕DR', (⎕DR data), 'and', (⎕DR data2))
+                    :EndFor
                     r,←assert ((data[?≢data])∊data) 't1' ('for ⎕DR', ⎕DR data)                  ⍝ random element is found
                     r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' ('for ⎕DR', ⎕DR data)  ⍝ All elements return 0 except last
                     r,←assert (((≢data)⍴1)≡data∊data) 't3' ('for ⎕DR', ⎕DR data)                ⍝ all elements return 1

--- a/unittest.apln
+++ b/unittest.apln
@@ -26,7 +26,7 @@
 
     ⍝ This function runs the tests
     ⍝ It takes 3 mandatory arguments [test_namespace] [verbose= 1|0] [stop=1|0]
-    ∇ RunTests args ;testNS;tests;nPass;nFail
+    ∇ RunTests args ;testNS;tests;tList;expr;t;r;nPass;nFail
         st←⎕AI[2] ⍝ Start time of execution of tests 
         ⎕←''
         :Section parseArguments ⍝ This section parses and verifies input arguments


### PR DESCRIPTION
Verbose test log:

```
      unittest.RunTests test_membership 1 0

Options:
      verbose: 1
      stop: 0

 #.test_membership.Test_DR 
 tb1  for ⎕DR 11 :  [OK] 
 tb2  for ⎕DR 11 :  [OK] 
 tb3  for ⎕DR 11 :  [OK] 
 tcrossBool  for ⎕DR 11 and 83 :  [OK] 
 tcrossBool  for ⎕DR 11 and 83 :  [OK] 
 tcrossBool  for ⎕DR 11 and 163 :  [OK] 
 tcrossBool  for ⎕DR 11 and 163 :  [OK] 
 tcrossBool  for ⎕DR 11 and 323 :  [OK] 
 tcrossBool  for ⎕DR 11 and 323 :  [OK] 
 tcrossBool  for ⎕DR 11 and 80 :  [OK] 
 tcrossBool  for ⎕DR 11 and 80 :  [OK] 
 tcrossBool  for ⎕DR 11 and 160 :  [OK] 
 tcrossBool  for ⎕DR 11 and 160 :  [OK] 
 tcrossBool  for ⎕DR 11 and 320 :  [OK] 
 tcrossBool  for ⎕DR 11 and 320 :  [OK] 
 tcrossBool  for ⎕DR 11 and 326 :  [OK] 
 tcrossBool  for ⎕DR 11 and 326 :  [OK] 
 tcrossBool  for ⎕DR 11 and 645 :  [OK] 
 tcrossBool  for ⎕DR 11 and 645 :  [OK] 
 tcrossBool  for ⎕DR 11 and 1287 :  [OK] 
 tcrossBool  for ⎕DR 11 and 1287 :  [OK] 
 tcrossBool  for ⎕DR 11 and 1289 :  [OK] 
 tcrossBool  for ⎕DR 11 and 1289 :  [OK] 
 tcross0  for ⎕DR 83 and 83 :  [OK] 
 tcross1  for ⎕DR 83 and 163 :  [OK] 
 tcross2  for ⎕DR 83 and 163 :  [OK] 
 tcross3  for ⎕DR 83 and 163 :  [OK] 
 tcross4  for ⎕DR 83 and 163 :  [OK] 
 tcross1  for ⎕DR 83 and 323 :  [OK] 
 tcross2  for ⎕DR 83 and 323 :  [OK] 
 tcross3  for ⎕DR 83 and 323 :  [OK] 
 tcross4  for ⎕DR 83 and 323 :  [OK] 
 tcross1  for ⎕DR 83 and 80 :  [OK] 
 tcross2  for ⎕DR 83 and 80 :  [OK] 
 tcross3  for ⎕DR 83 and 80 :  [OK] 
 tcross4  for ⎕DR 83 and 80 :  [OK] 
 tcross1  for ⎕DR 83 and 160 :  [OK] 
 tcross2  for ⎕DR 83 and 160 :  [OK] 
 tcross3  for ⎕DR 83 and 160 :  [OK] 
 tcross4  for ⎕DR 83 and 160 :  [OK] 
 tcross1  for ⎕DR 83 and 320 :  [OK] 
 tcross2  for ⎕DR 83 and 320 :  [OK] 
 tcross3  for ⎕DR 83 and 320 :  [OK] 
 tcross4  for ⎕DR 83 and 320 :  [OK] 
 tcross1  for ⎕DR 83 and 326 :  [OK] 
 tcross2  for ⎕DR 83 and 326 :  [OK] 
 tcross3  for ⎕DR 83 and 326 :  [OK] 
 tcross4  for ⎕DR 83 and 326 :  [OK] 
 tcross1  for ⎕DR 83 and 645 :  [OK] 
 tcross2  for ⎕DR 83 and 645 :  [OK] 
 tcross3  for ⎕DR 83 and 645 :  [OK] 
 tcross4  for ⎕DR 83 and 645 :  [OK] 
 tcross1  for ⎕DR 83 and 1287 :  [OK] 
 tcross2  for ⎕DR 83 and 1287 :  [OK] 
 tcross3  for ⎕DR 83 and 1287 :  [OK] 
 tcross4  for ⎕DR 83 and 1287 :  [OK] 
 tcross1  for ⎕DR 83 and 1289 :  [OK] 
 tcross2  for ⎕DR 83 and 1289 :  [OK] 
 tcross3  for ⎕DR 83 and 1289 :  [OK] 
 tcross4  for ⎕DR 83 and 1289 :  [OK] 
 t1  for ⎕DR 83 :  [OK] 
 t2  for ⎕DR 83 :  [OK] 
 t3  for ⎕DR 83 :  [OK] 
 t4.1  for ⎕DR 83 :  [OK] 
 tcross1  for ⎕DR 163 and 83 :  [OK] 
 tcross2  for ⎕DR 163 and 83 :  [OK] 
 tcross3  for ⎕DR 163 and 83 :  [OK] 
 tcross4  for ⎕DR 163 and 83 :  [OK] 
 tcross0  for ⎕DR 163 and 163 :  [OK] 
 tcross1  for ⎕DR 163 and 323 :  [OK] 
 tcross2  for ⎕DR 163 and 323 :  [OK] 
 tcross3  for ⎕DR 163 and 323 :  [OK] 
 tcross4  for ⎕DR 163 and 323 :  [OK] 
 tcross1  for ⎕DR 163 and 80 :  [OK] 
 tcross2  for ⎕DR 163 and 80 :  [OK] 
 tcross3  for ⎕DR 163 and 80 :  [OK] 
 tcross4  for ⎕DR 163 and 80 :  [OK] 
 tcross1  for ⎕DR 163 and 160 :  [OK] 
 tcross2  for ⎕DR 163 and 160 :  [OK] 
 tcross3  for ⎕DR 163 and 160 :  [OK] 
 tcross4  for ⎕DR 163 and 160 :  [OK] 
 tcross1  for ⎕DR 163 and 320 :  [OK] 
 tcross2  for ⎕DR 163 and 320 :  [OK] 
 tcross3  for ⎕DR 163 and 320 :  [OK] 
 tcross4  for ⎕DR 163 and 320 :  [OK] 
 tcross1  for ⎕DR 163 and 326 :  [OK] 
 tcross2  for ⎕DR 163 and 326 :  [OK] 
 tcross3  for ⎕DR 163 and 326 :  [OK] 
 tcross4  for ⎕DR 163 and 326 :  [OK] 
 tcross1  for ⎕DR 163 and 645 :  [OK] 
 tcross2  for ⎕DR 163 and 645 :  [OK] 
 tcross3  for ⎕DR 163 and 645 :  [OK] 
 tcross4  for ⎕DR 163 and 645 :  [OK] 
 tcross1  for ⎕DR 163 and 1287 :  [OK] 
 tcross2  for ⎕DR 163 and 1287 :  [OK] 
 tcross3  for ⎕DR 163 and 1287 :  [OK] 
 tcross4  for ⎕DR 163 and 1287 :  [OK] 
 tcross1  for ⎕DR 163 and 1289 :  [OK] 
 tcross2  for ⎕DR 163 and 1289 :  [OK] 
 tcross3  for ⎕DR 163 and 1289 :  [OK] 
 tcross4  for ⎕DR 163 and 1289 :  [OK] 
 t1  for ⎕DR 163 :  [OK] 
 t2  for ⎕DR 163 :  [OK] 
 t3  for ⎕DR 163 :  [OK] 
 t4.1  for ⎕DR 163 :  [OK] 
 tcross1  for ⎕DR 323 and 83 :  [OK] 
 tcross2  for ⎕DR 323 and 83 :  [OK] 
 tcross3  for ⎕DR 323 and 83 :  [OK] 
 tcross4  for ⎕DR 323 and 83 :  [OK] 
 tcross1  for ⎕DR 323 and 163 :  [OK] 
 tcross2  for ⎕DR 323 and 163 :  [OK] 
 tcross3  for ⎕DR 323 and 163 :  [OK] 
 tcross4  for ⎕DR 323 and 163 :  [OK] 
 tcross0  for ⎕DR 323 and 323 :  [OK] 
 tcross1  for ⎕DR 323 and 80 :  [OK] 
 tcross2  for ⎕DR 323 and 80 :  [OK] 
 tcross3  for ⎕DR 323 and 80 :  [OK] 
 tcross4  for ⎕DR 323 and 80 :  [OK] 
 tcross1  for ⎕DR 323 and 160 :  [OK] 
 tcross2  for ⎕DR 323 and 160 :  [OK] 
 tcross3  for ⎕DR 323 and 160 :  [OK] 
 tcross4  for ⎕DR 323 and 160 :  [OK] 
 tcross1  for ⎕DR 323 and 320 :  [OK] 
 tcross2  for ⎕DR 323 and 320 :  [OK] 
 tcross3  for ⎕DR 323 and 320 :  [OK] 
 tcross4  for ⎕DR 323 and 320 :  [OK] 
 tcross1  for ⎕DR 323 and 326 :  [OK] 
 tcross2  for ⎕DR 323 and 326 :  [OK] 
 tcross3  for ⎕DR 323 and 326 :  [OK] 
 tcross4  for ⎕DR 323 and 326 :  [OK] 
 tcross1  for ⎕DR 323 and 645 :  [OK] 
 tcross2  for ⎕DR 323 and 645 :  [OK] 
 tcross3  for ⎕DR 323 and 645 :  [OK] 
 tcross4  for ⎕DR 323 and 645 :  [OK] 
 tcross1  for ⎕DR 323 and 1287 :  [OK] 
 tcross2  for ⎕DR 323 and 1287 :  [OK] 
 tcross3  for ⎕DR 323 and 1287 :  [OK] 
 tcross4  for ⎕DR 323 and 1287 :  [OK] 
 tcross1  for ⎕DR 323 and 1289 :  [OK] 
 tcross2  for ⎕DR 323 and 1289 :  [OK] 
 tcross3  for ⎕DR 323 and 1289 :  [OK] 
 tcross4  for ⎕DR 323 and 1289 :  [OK] 
 t1  for ⎕DR 323 :  [OK] 
 t2  for ⎕DR 323 :  [OK] 
 t3  for ⎕DR 323 :  [OK] 
 t4.1  for ⎕DR 323 :  [OK] 
 tcross1  for ⎕DR 80 and 83 :  [OK] 
 tcross2  for ⎕DR 80 and 83 :  [OK] 
 tcross3  for ⎕DR 80 and 83 :  [OK] 
 tcross4  for ⎕DR 80 and 83 :  [OK] 
 tcross1  for ⎕DR 80 and 163 :  [OK] 
 tcross2  for ⎕DR 80 and 163 :  [OK] 
 tcross3  for ⎕DR 80 and 163 :  [OK] 
 tcross4  for ⎕DR 80 and 163 :  [OK] 
 tcross1  for ⎕DR 80 and 323 :  [OK] 
 tcross2  for ⎕DR 80 and 323 :  [OK] 
 tcross3  for ⎕DR 80 and 323 :  [OK] 
 tcross4  for ⎕DR 80 and 323 :  [OK] 
 tcross0  for ⎕DR 80 and 80 :  [OK] 
 tcross1  for ⎕DR 80 and 160 :  [OK] 
 tcross2  for ⎕DR 80 and 160 :  [OK] 
 tcross3  for ⎕DR 80 and 160 :  [OK] 
 tcross4  for ⎕DR 80 and 160 :  [OK] 
 tcross1  for ⎕DR 80 and 320 :  [OK] 
 tcross2  for ⎕DR 80 and 320 :  [OK] 
 tcross3  for ⎕DR 80 and 320 :  [OK] 
 tcross4  for ⎕DR 80 and 320 :  [OK] 
 tcross1  for ⎕DR 80 and 326 :  [OK] 
 tcross2  for ⎕DR 80 and 326 :  [OK] 
 tcross3  for ⎕DR 80 and 326 :  [OK] 
 tcross4  for ⎕DR 80 and 326 :  [OK] 
 tcross1  for ⎕DR 80 and 645 :  [OK] 
 tcross2  for ⎕DR 80 and 645 :  [OK] 
 tcross3  for ⎕DR 80 and 645 :  [OK] 
 tcross4  for ⎕DR 80 and 645 :  [OK] 
 tcross1  for ⎕DR 80 and 1287 :  [OK] 
 tcross2  for ⎕DR 80 and 1287 :  [OK] 
 tcross3  for ⎕DR 80 and 1287 :  [OK] 
 tcross4  for ⎕DR 80 and 1287 :  [OK] 
 tcross1  for ⎕DR 80 and 1289 :  [OK] 
 tcross2  for ⎕DR 80 and 1289 :  [OK] 
 tcross3  for ⎕DR 80 and 1289 :  [OK] 
 tcross4  for ⎕DR 80 and 1289 :  [OK] 
 t1  for ⎕DR 80 :  [OK] 
 t2  for ⎕DR 80 :  [OK] 
 t3  for ⎕DR 80 :  [OK] 
 t4.2  for ⎕DR 80 :  [OK] 
 tcross1  for ⎕DR 160 and 83 :  [OK] 
 tcross2  for ⎕DR 160 and 83 :  [OK] 
 tcross3  for ⎕DR 160 and 83 :  [OK] 
 tcross4  for ⎕DR 160 and 83 :  [OK] 
 tcross1  for ⎕DR 160 and 163 :  [OK] 
 tcross2  for ⎕DR 160 and 163 :  [OK] 
 tcross3  for ⎕DR 160 and 163 :  [OK] 
 tcross4  for ⎕DR 160 and 163 :  [OK] 
 tcross1  for ⎕DR 160 and 323 :  [OK] 
 tcross2  for ⎕DR 160 and 323 :  [OK] 
 tcross3  for ⎕DR 160 and 323 :  [OK] 
 tcross4  for ⎕DR 160 and 323 :  [OK] 
 tcross1  for ⎕DR 160 and 80 :  [OK] 
 tcross2  for ⎕DR 160 and 80 :  [OK] 
 tcross3  for ⎕DR 160 and 80 :  [OK] 
 tcross4  for ⎕DR 160 and 80 :  [OK] 
 tcross0  for ⎕DR 160 and 160 :  [OK] 
 tcross1  for ⎕DR 160 and 320 :  [OK] 
 tcross2  for ⎕DR 160 and 320 :  [OK] 
 tcross3  for ⎕DR 160 and 320 :  [OK] 
 tcross4  for ⎕DR 160 and 320 :  [OK] 
 tcross1  for ⎕DR 160 and 326 :  [OK] 
 tcross2  for ⎕DR 160 and 326 :  [OK] 
 tcross3  for ⎕DR 160 and 326 :  [OK] 
 tcross4  for ⎕DR 160 and 326 :  [OK] 
 tcross1  for ⎕DR 160 and 645 :  [OK] 
 tcross2  for ⎕DR 160 and 645 :  [OK] 
 tcross3  for ⎕DR 160 and 645 :  [OK] 
 tcross4  for ⎕DR 160 and 645 :  [OK] 
 tcross1  for ⎕DR 160 and 1287 :  [OK] 
 tcross2  for ⎕DR 160 and 1287 :  [OK] 
 tcross3  for ⎕DR 160 and 1287 :  [OK] 
 tcross4  for ⎕DR 160 and 1287 :  [OK] 
 tcross1  for ⎕DR 160 and 1289 :  [OK] 
 tcross2  for ⎕DR 160 and 1289 :  [OK] 
 tcross3  for ⎕DR 160 and 1289 :  [OK] 
 tcross4  for ⎕DR 160 and 1289 :  [OK] 
 t1  for ⎕DR 160 :  [OK] 
 t2  for ⎕DR 160 :  [OK] 
 t3  for ⎕DR 160 :  [OK] 
 t4.2  for ⎕DR 160 :  [OK] 
 tcross1  for ⎕DR 320 and 83 :  [OK] 
 tcross2  for ⎕DR 320 and 83 :  [OK] 
 tcross3  for ⎕DR 320 and 83 :  [OK] 
 tcross4  for ⎕DR 320 and 83 :  [OK] 
 tcross1  for ⎕DR 320 and 163 :  [OK] 
 tcross2  for ⎕DR 320 and 163 :  [OK] 
 tcross3  for ⎕DR 320 and 163 :  [OK] 
 tcross4  for ⎕DR 320 and 163 :  [OK] 
 tcross1  for ⎕DR 320 and 323 :  [OK] 
 tcross2  for ⎕DR 320 and 323 :  [OK] 
 tcross3  for ⎕DR 320 and 323 :  [OK] 
 tcross4  for ⎕DR 320 and 323 :  [OK] 
 tcross1  for ⎕DR 320 and 80 :  [OK] 
 tcross2  for ⎕DR 320 and 80 :  [OK] 
 tcross3  for ⎕DR 320 and 80 :  [OK] 
 tcross4  for ⎕DR 320 and 80 :  [OK] 
 tcross1  for ⎕DR 320 and 160 :  [OK] 
 tcross2  for ⎕DR 320 and 160 :  [OK] 
 tcross3  for ⎕DR 320 and 160 :  [OK] 
 tcross4  for ⎕DR 320 and 160 :  [OK] 
 tcross0  for ⎕DR 320 and 320 :  [OK] 
 tcross1  for ⎕DR 320 and 326 :  [OK] 
 tcross2  for ⎕DR 320 and 326 :  [OK] 
 tcross3  for ⎕DR 320 and 326 :  [OK] 
 tcross4  for ⎕DR 320 and 326 :  [OK] 
 tcross1  for ⎕DR 320 and 645 :  [OK] 
 tcross2  for ⎕DR 320 and 645 :  [OK] 
 tcross3  for ⎕DR 320 and 645 :  [OK] 
 tcross4  for ⎕DR 320 and 645 :  [OK] 
 tcross1  for ⎕DR 320 and 1287 :  [OK] 
 tcross2  for ⎕DR 320 and 1287 :  [OK] 
 tcross3  for ⎕DR 320 and 1287 :  [OK] 
 tcross4  for ⎕DR 320 and 1287 :  [OK] 
 tcross1  for ⎕DR 320 and 1289 :  [OK] 
 tcross2  for ⎕DR 320 and 1289 :  [OK] 
 tcross3  for ⎕DR 320 and 1289 :  [OK] 
 tcross4  for ⎕DR 320 and 1289 :  [OK] 
 t1  for ⎕DR 320 :  [OK] 
 t2  for ⎕DR 320 :  [OK] 
 t3  for ⎕DR 320 :  [OK] 
 t4.2  for ⎕DR 320 :  [OK] 
 tcross1  for ⎕DR 326 and 83 :  [OK] 
 tcross2  for ⎕DR 326 and 83 :  [OK] 
 tcross3  for ⎕DR 326 and 83 :  [OK] 
 tcross4  for ⎕DR 326 and 83 :  [OK] 
 tcross1  for ⎕DR 326 and 163 :  [OK] 
 tcross2  for ⎕DR 326 and 163 :  [OK] 
 tcross3  for ⎕DR 326 and 163 :  [OK] 
 tcross4  for ⎕DR 326 and 163 :  [OK] 
 tcross1  for ⎕DR 326 and 323 :  [OK] 
 tcross2  for ⎕DR 326 and 323 :  [OK] 
 tcross3  for ⎕DR 326 and 323 :  [OK] 
 tcross4  for ⎕DR 326 and 323 :  [OK] 
 tcross1  for ⎕DR 326 and 80 :  [OK] 
 tcross2  for ⎕DR 326 and 80 :  [OK] 
 tcross3  for ⎕DR 326 and 80 :  [OK] 
 tcross4  for ⎕DR 326 and 80 :  [OK] 
 tcross1  for ⎕DR 326 and 160 :  [OK] 
 tcross2  for ⎕DR 326 and 160 :  [OK] 
 tcross3  for ⎕DR 326 and 160 :  [OK] 
 tcross4  for ⎕DR 326 and 160 :  [OK] 
 tcross1  for ⎕DR 326 and 320 :  [OK] 
 tcross2  for ⎕DR 326 and 320 :  [OK] 
 tcross3  for ⎕DR 326 and 320 :  [OK] 
 tcross4  for ⎕DR 326 and 320 :  [OK] 
 tcross0  for ⎕DR 326 and 326 :  [OK] 
 tcross1  for ⎕DR 326 and 645 :  [OK] 
 tcross2  for ⎕DR 326 and 645 :  [OK] 
 tcross3  for ⎕DR 326 and 645 :  [OK] 
 tcross4  for ⎕DR 326 and 645 :  [OK] 
 tcross1  for ⎕DR 326 and 1287 :  [OK] 
 tcross2  for ⎕DR 326 and 1287 :  [OK] 
 tcross3  for ⎕DR 326 and 1287 :  [OK] 
 tcross4  for ⎕DR 326 and 1287 :  [OK] 
 tcross1  for ⎕DR 326 and 1289 :  [OK] 
 tcross2  for ⎕DR 326 and 1289 :  [OK] 
 tcross3  for ⎕DR 326 and 1289 :  [OK] 
 tcross4  for ⎕DR 326 and 1289 :  [OK] 
 t1  for ⎕DR 326 :  [OK] 
 t2  for ⎕DR 326 :  [OK] 
 t3  for ⎕DR 326 :  [OK] 
 tcross1  for ⎕DR 645 and 83 :  [OK] 
 tcross2  for ⎕DR 645 and 83 :  [OK] 
 tcross3  for ⎕DR 645 and 83 :  [OK] 
 tcross4  for ⎕DR 645 and 83 :  [OK] 
 tcross1  for ⎕DR 645 and 163 :  [OK] 
 tcross2  for ⎕DR 645 and 163 :  [OK] 
 tcross3  for ⎕DR 645 and 163 :  [OK] 
 tcross4  for ⎕DR 645 and 163 :  [OK] 
 tcross1  for ⎕DR 645 and 323 :  [OK] 
 tcross2  for ⎕DR 645 and 323 :  [OK] 
 tcross3  for ⎕DR 645 and 323 :  [OK] 
 tcross4  for ⎕DR 645 and 323 :  [OK] 
 tcross1  for ⎕DR 645 and 80 :  [OK] 
 tcross2  for ⎕DR 645 and 80 :  [OK] 
 tcross3  for ⎕DR 645 and 80 :  [OK] 
 tcross4  for ⎕DR 645 and 80 :  [OK] 
 tcross1  for ⎕DR 645 and 160 :  [OK] 
 tcross2  for ⎕DR 645 and 160 :  [OK] 
 tcross3  for ⎕DR 645 and 160 :  [OK] 
 tcross4  for ⎕DR 645 and 160 :  [OK] 
 tcross1  for ⎕DR 645 and 320 :  [OK] 
 tcross2  for ⎕DR 645 and 320 :  [OK] 
 tcross3  for ⎕DR 645 and 320 :  [OK] 
 tcross4  for ⎕DR 645 and 320 :  [OK] 
 tcross1  for ⎕DR 645 and 326 :  [OK] 
 tcross2  for ⎕DR 645 and 326 :  [OK] 
 tcross3  for ⎕DR 645 and 326 :  [OK] 
 tcross4  for ⎕DR 645 and 326 :  [OK] 
 tcross0  for ⎕DR 645 and 645 :  [OK] 
 tcross1  for ⎕DR 645 and 1287 :  [OK] 
 tcross2  for ⎕DR 645 and 1287 :  [OK] 
 tcross3  for ⎕DR 645 and 1287 :  [OK] 
 tcross4  for ⎕DR 645 and 1287 :  [OK] 
 tcross1  for ⎕DR 645 and 1289 :  [OK] 
 tcross2  for ⎕DR 645 and 1289 :  [OK] 
 tcross3  for ⎕DR 645 and 1289 :  [OK] 
 tcross4  for ⎕DR 645 and 1289 :  [OK] 
 t1  for ⎕DR 645 :  [OK] 
 t2  for ⎕DR 645 :  [OK] 
 t3  for ⎕DR 645 :  [OK] 
 t4.1  for ⎕DR 645 :  [OK] 
 tcross1  for ⎕DR 1287 and 83 :  [OK] 
 tcross2  for ⎕DR 1287 and 83 :  [OK] 
 tcross3  for ⎕DR 1287 and 83 :  [OK] 
 tcross4  for ⎕DR 1287 and 83 :  [OK] 
 tcross1  for ⎕DR 1287 and 163 :  [OK] 
 tcross2  for ⎕DR 1287 and 163 :  [OK] 
 tcross3  for ⎕DR 1287 and 163 :  [OK] 
 tcross4  for ⎕DR 1287 and 163 :  [OK] 
 tcross1  for ⎕DR 1287 and 323 :  [OK] 
 tcross2  for ⎕DR 1287 and 323 :  [OK] 
 tcross3  for ⎕DR 1287 and 323 :  [OK] 
 tcross4  for ⎕DR 1287 and 323 :  [OK] 
 tcross1  for ⎕DR 1287 and 80 :  [OK] 
 tcross2  for ⎕DR 1287 and 80 :  [OK] 
 tcross3  for ⎕DR 1287 and 80 :  [OK] 
 tcross4  for ⎕DR 1287 and 80 :  [OK] 
 tcross1  for ⎕DR 1287 and 160 :  [OK] 
 tcross2  for ⎕DR 1287 and 160 :  [OK] 
 tcross3  for ⎕DR 1287 and 160 :  [OK] 
 tcross4  for ⎕DR 1287 and 160 :  [OK] 
 tcross1  for ⎕DR 1287 and 320 :  [OK] 
 tcross2  for ⎕DR 1287 and 320 :  [OK] 
 tcross3  for ⎕DR 1287 and 320 :  [OK] 
 tcross4  for ⎕DR 1287 and 320 :  [OK] 
 tcross1  for ⎕DR 1287 and 326 :  [OK] 
 tcross2  for ⎕DR 1287 and 326 :  [OK] 
 tcross3  for ⎕DR 1287 and 326 :  [OK] 
 tcross4  for ⎕DR 1287 and 326 :  [OK] 
 tcross1  for ⎕DR 1287 and 645 :  [OK] 
 tcross2  for ⎕DR 1287 and 645 :  [OK] 
 tcross3  for ⎕DR 1287 and 645 :  [OK] 
 tcross4  for ⎕DR 1287 and 645 :  [OK] 
 tcross0  for ⎕DR 1287 and 1287 :  [OK] 
 tcross1  for ⎕DR 1287 and 1289 :  [OK] 
 tcross2  for ⎕DR 1287 and 1289 :  [OK] 
 tcross3  for ⎕DR 1287 and 1289 :  [OK] 
 tcross4  for ⎕DR 1287 and 1289 :  [OK] 
 t1  for ⎕DR 1287 :  [OK] 
 t2  for ⎕DR 1287 :  [OK] 
 t3  for ⎕DR 1287 :  [OK] 
 t4.1  for ⎕DR 1287 :  [OK] 
 tcross1  for ⎕DR 1289 and 83 :  [OK] 
 tcross2  for ⎕DR 1289 and 83 :  [OK] 
 tcross3  for ⎕DR 1289 and 83 :  [OK] 
 tcross4  for ⎕DR 1289 and 83 :  [OK] 
 tcross1  for ⎕DR 1289 and 163 :  [OK] 
 tcross2  for ⎕DR 1289 and 163 :  [OK] 
 tcross3  for ⎕DR 1289 and 163 :  [OK] 
 tcross4  for ⎕DR 1289 and 163 :  [OK] 
 tcross1  for ⎕DR 1289 and 323 :  [OK] 
 tcross2  for ⎕DR 1289 and 323 :  [OK] 
 tcross3  for ⎕DR 1289 and 323 :  [OK] 
 tcross4  for ⎕DR 1289 and 323 :  [OK] 
 tcross1  for ⎕DR 1289 and 80 :  [OK] 
 tcross2  for ⎕DR 1289 and 80 :  [OK] 
 tcross3  for ⎕DR 1289 and 80 :  [OK] 
 tcross4  for ⎕DR 1289 and 80 :  [OK] 
 tcross1  for ⎕DR 1289 and 160 :  [OK] 
 tcross2  for ⎕DR 1289 and 160 :  [OK] 
 tcross3  for ⎕DR 1289 and 160 :  [OK] 
 tcross4  for ⎕DR 1289 and 160 :  [OK] 
 tcross1  for ⎕DR 1289 and 320 :  [OK] 
 tcross2  for ⎕DR 1289 and 320 :  [OK] 
 tcross3  for ⎕DR 1289 and 320 :  [OK] 
 tcross4  for ⎕DR 1289 and 320 :  [OK] 
 tcross1  for ⎕DR 1289 and 326 :  [OK] 
 tcross2  for ⎕DR 1289 and 326 :  [OK] 
 tcross3  for ⎕DR 1289 and 326 :  [OK] 
 tcross4  for ⎕DR 1289 and 326 :  [OK] 
 tcross1  for ⎕DR 1289 and 645 :  [OK] 
 tcross2  for ⎕DR 1289 and 645 :  [OK] 
 tcross3  for ⎕DR 1289 and 645 :  [OK] 
 tcross4  for ⎕DR 1289 and 645 :  [OK] 
 tcross1  for ⎕DR 1289 and 1287 :  [OK] 
 tcross2  for ⎕DR 1289 and 1287 :  [OK] 
 tcross3  for ⎕DR 1289 and 1287 :  [OK] 
 tcross4  for ⎕DR 1289 and 1287 :  [OK] 
 tcross0  for ⎕DR 1289 and 1289 :  [OK] 
 t1  for ⎕DR 1289 :  [OK] 
 t2  for ⎕DR 1289 :  [OK] 
 t3  for ⎕DR 1289 :  [OK] 
 t4.1  for ⎕DR 1289 :  [OK] 

Tests completed:  432 ran, 0 failed test, 432 successes in 553.868 s
```

EDIT: updated log for commit [0aa9776](https://github.com/sloorush/bb-test-apl/pull/2/commits/0aa9776f5a1ff7df6d7a3aac6e36fa16969c7fd9)