### PR TITLE
run all tests twice with different ⎕FR values

### DIFF
--- a/test_membership.apln
+++ b/test_membership.apln
@@ -63,7 +63,7 @@
 
                     ⍝ same type tests
                     r,←assert ((data[?≢data])∊data) 't1' desc                  ⍝ random element is found
-                    r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' desc  ⍝ All elements return 0 except last
+                    ⍝ r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' desc  ⍝ All elements return 0 except last
                     r,←assert (((≢data)⍴1)≡data∊data) 't3' desc                ⍝ all elements return 1
                     r,←assert (0≡5E50∊data) 't4' desc                          ⍝ huge element outside set is not found
 
@@ -71,17 +71,17 @@
                     d←data[?≢data]
                     :If ct
                         ⍝ case for CT default & is skipped for FR=1287
-                        :If ((data≡Hdbl) ∧ (fr≡1)) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
+                        :If (data≡Hdbl) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
                             ⍝ next number is equal for Hdbl as it comes under the region of tolerant equality
-                            r,←assert (1≡(d∊d+1)) 'CTDefault' desc
+                            r,←assert ((1≡(d∊d+1)) ∨ (fr=2 ∧ case≡'Hdbl')) 'CTDefault' desc ⍝ d and d+1 cannot be equal with FR 1287 with Hdbl
                         :Else
                             :Continue ⍝ not relevant for other datatypes
                         :EndIf
                     :Else
-                        :If ((⎕DR data) ∊ 80 160 320 326) ∨ ((fr=1) ∧ (case≡'Hfl'))
+                        :If ((⎕DR data) ∊ 80 160 320 326)
                             :continue
                         :EndIf
-                        r,←assert (0≡(d∊d+1)) 'CTZero' desc
+                        r,←assert ((0≡(d∊d+1)) ∨ (fr=1 ∧ case≡'Hfl')) 'CTZero' desc ⍝ d and d+1 cannot be unequal with FR 645 with Hfl
                     :EndIf
                 :EndFor
 
@@ -94,7 +94,8 @@
                 r,←assert (1 1≡bool∊bool) 'tb3' desc
                 
                 ⍝ Boolean cross type tests
-                :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx'  'Hdbl' 'Hfl' 'Hcmplx' ⍝ bool requires separate cross tests because of overlap with i1
+                ⍝ bool requires separate cross tests because of overlap with i1
+                :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx'  'Hdbl' 'Hfl' 'Hcmplx'
                     data2←⍎case2
                     desc←testDesc⍬
                     :If (83≠type←⎕DR data2) ⍝ special case because of overlap

--- a/test_membership.apln
+++ b/test_membership.apln
@@ -22,7 +22,7 @@
         ⍝ Hfl is 1287 but higher order to test for CT value
         ⍝ far intervals are chosen for non overlap 
         ⍝ with region of tolerant equality
-        ⎕FR←1287 ⋄ Hfl←{⍵,-⍵}2E15+(500×⍳10) ⋄ ⎕FR←645 
+        ⎕FR←1287 ⋄ Hfl←{⍵,-⍵}2E29+(500×⍳10) ⋄ ⎕FR←645 
         Hcmplx←{⍵,-⍵}(1E14J1E14×⍳20)                  ⍝ 1289 but higher order to test for CT value
         
         ct_default←1E¯14
@@ -41,6 +41,9 @@
 
                 :For case :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
                     data←⍎case
+                    :If fr=2 ∧ ((case≡'cmplx') ∨ (case≡'Hcmplx'))
+                        :Continue
+                    :EndIf
 
                     ⍝ Cross type tests
                     :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
@@ -66,16 +69,16 @@
 
                     ⍝ tests with comparision tolerance
                     d←data[?≢data]
-                    :If ct ∧ (fr=1)
+                    :If ct
                         ⍝ case for CT default & is skipped for FR=1287
-                        :If (data≡Hdbl) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
+                        :If ((data≡Hdbl) ∧ (fr≡1)) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
                             ⍝ next number is equal for Hdbl as it comes under the region of tolerant equality
                             r,←assert (1≡(d∊d+1)) 'CTDefault' desc
                         :Else
                             :Continue ⍝ not relevant for other datatypes
                         :EndIf
                     :Else
-                        :If ((⎕DR data) ∊ 80 160 320 326)
+                        :If ((⎕DR data) ∊ 80 160 320 326) ∨ ((fr=1) ∧ (case≡'Hfl'))
                             :continue
                         :EndIf
                         r,←assert (0≡(d∊d+1)) 'CTZero' desc

--- a/test_membership.apln
+++ b/test_membership.apln
@@ -28,7 +28,7 @@
         ct_default←1E¯14
         dct_default←1E¯28
         fr_dbl←645
-        fr_fl←1287
+        fr_decf←1287
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
@@ -37,11 +37,11 @@
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
 
             :For fr :In 1 2
-                ⎕FR←fr⊃fr_dbl fr_fl
+                ⎕FR←fr⊃fr_dbl fr_decf
 
                 :For case :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
                     data←⍎case
-                    :If fr=2 ∧ ((case≡'cmplx') ∨ (case≡'Hcmplx'))
+                    :If ⎕FR=fr_decf ∧ 1289=⎕DR data ⍝ ⎕FR=1287 is not recommended to be used with cmplx
                         :Continue
                     :EndIf
 
@@ -70,19 +70,17 @@
 
                     ⍝ tests with comparision tolerance
                     d←data[?≢data]
-                    :If ct
+                    :If ct ⍝ tolerant
                         ⍝ case for CT default & is skipped for FR=1287
-                        :If (data≡Hdbl) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
-                            ⍝ next number is equal for Hdbl as it comes under the region of tolerant equality
-                            r,← 'CTDefault' desc Assert (1≡(d∊d+1)) ∨ (fr=2 ∧ case≡'Hdbl') ⍝ d and d+1 cannot be equal with FR 1287 with Hdbl
-                        :Else
-                            :Continue ⍝ not relevant for other datatypes
+                        :If (⊂data)∊Hdbl Hfl Hcmplx
+                            ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF
+                            r,← 'CTDefault' desc Assert ((1≡(d∊d+1)) ∨ (fr=2 ∧ case≡'Hdbl'))
                         :EndIf
-                    :Else
-                        :If ((⎕DR data) ∊ 80 160 320 326)
-                            :continue
+                    :Else  ⍝ exact
+                        :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
+                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
+                            r,← 'CTZero' desc Assert ((0≡(d∊d+1)) ∨ (fr=1 ∧ case≡'Hfl'))
                         :EndIf
-                        r,← 'CTZero' desc Assert ((0≡(d∊d+1)) ∨ (fr=1 ∧ case≡'Hfl')) ⍝ d and d+1 cannot be unequal with FR 645 with Hfl
                     :EndIf
                 :EndFor
 
@@ -103,7 +101,7 @@
                         r,← 'tcrossBool2' desc Assert ((≢data2)⍴0) ≡ (data2∊bool)     ⍝ All elements return 0
                     :Else
                         r,← 'tcrossBooli1' desc Assert ((≢bool)⍴1) ≡ (bool∊data2)     ⍝ All elements return 1
-                        r,← 'tcrossBooli2' desc Assert ((⊣,(⌽⊣))((1↓((≢i1)÷2)⍴0),1)) ≡ (data2∊bool) ⍝ overlaping 0 1 returns 1
+                        r,← 'tcrossBooli2' desc Assert ({⍵,(⌽⍵)}((1↓((≢i1)÷2)⍴0),1)) ≡ (data2∊bool) ⍝ overlaping 0 1 returns 1
                     :EndIf
                 :EndFor
                 ⍝ disposing case for testDesc

--- a/test_membership.apln
+++ b/test_membership.apln
@@ -22,7 +22,7 @@
         ⍝ Hfl is 1287 but higher order to test for CT value
         ⍝ far intervals are chosen for non overlap 
         ⍝ with region of tolerant equality
-        ⎕FR←1287 ⋄ Hfl←{⍵,-⍵}2E29+(500×⍳10) ⋄ ⎕FR←645 
+        ⎕FR←1287 ⋄ Hfl←{⍵,-⍵}2E29+(1E16×⍳10) ⋄ ⎕FR←645 
         Hcmplx←{⍵,-⍵}(1E14J1E14×⍳20)                  ⍝ 1289 but higher order to test for CT value
         
         ct_default←1E¯14
@@ -63,7 +63,7 @@
 
                     ⍝ same type tests
                     r,←assert ((data[?≢data])∊data) 't1' desc                  ⍝ random element is found
-                    ⍝ r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' desc  ⍝ All elements return 0 except last
+                    r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' desc  ⍝ All elements return 0 except last
                     r,←assert (((≢data)⍴1)≡data∊data) 't3' desc                ⍝ all elements return 1
                     r,←assert (0≡5E50∊data) 't4' desc                          ⍝ huge element outside set is not found
 

--- a/test_membership.apln
+++ b/test_membership.apln
@@ -27,78 +27,85 @@
         
         ct_default←1E¯14
         dct_default←1E¯28
+        fr_dbl←645
+        fr_fl←1287
 
         r←⍬
-        testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT}
+        testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
 
         :For ct :In 1 0 
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
 
-            :For case :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
-                data←⍎case
-                ⍝ Cross type tests
-                :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
+            :For fr :In 1 2
+                ⎕FR←fr⊃fr_dbl fr_fl
+
+                :For case :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
+                    data←⍎case
+
+                    ⍝ Cross type tests
+                    :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx' 'Hdbl' 'Hfl' 'Hcmplx'
+                        data2←⍎case2
+                        desc←testDesc⍬
+                        :If (data≡data2)
+                            r,←assert (((≢data)⍴1) ≡ (data∊data2)) 'tcross0' desc
+                            :Continue
+                        :EndIf
+                        r,←assert (((≢data)⍴0) ≡ (data∊data2)) 'tcross1' desc ⍝ no match, all return 0
+                        r,←assert (((≢data2)⍴0) ≡ (data2∊data)) 'tcross2' desc ⍝ no match, all return 0
+                        r,←assert (((≢data)⍴1) ≡ (data∊data,data2)) 'tcross3' desc ⍝ first data match, returns 1
+                        r,←assert ((((≢data)⍴1),((≢data2)⍴0))≡((data,data2)∊data)) 'tcross4' desc ⍝ data match, data2 no match
+                    :EndFor
+                    case2←⍬ ⍝ disposing case2 for testDesc
+                    desc←testDesc⍬
+
+                    ⍝ same type tests
+                    r,←assert ((data[?≢data])∊data) 't1' desc                  ⍝ random element is found
+                    r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' desc  ⍝ All elements return 0 except last
+                    r,←assert (((≢data)⍴1)≡data∊data) 't3' desc                ⍝ all elements return 1
+                    r,←assert (0≡5E50∊data) 't4' desc                          ⍝ huge element outside set is not found
+
+                    ⍝ tests with comparision tolerance
+                    d←data[?≢data]
+                    :If ct ∧ (fr=1)
+                        ⍝ case for CT default & is skipped for FR=1287
+                        :If (data≡Hdbl) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
+                            ⍝ next number is equal for Hdbl as it comes under the region of tolerant equality
+                            r,←assert (1≡(d∊d+1)) 'CTDefault' desc
+                        :Else
+                            :Continue ⍝ not relevant for other datatypes
+                        :EndIf
+                    :Else
+                        :If ((⎕DR data) ∊ 80 160 320 326)
+                            :continue
+                        :EndIf
+                        r,←assert (0≡(d∊d+1)) 'CTZero' desc
+                    :EndIf
+                :EndFor
+
+                ⍝ Booleans need special tests
+                case←'bool'
+                desc←testDesc⍬
+
+                r,←assert (0∊0) 'tb1' desc
+                r,←assert (~0∊1) 'tb2' desc
+                r,←assert (1 1≡bool∊bool) 'tb3' desc
+                
+                ⍝ Boolean cross type tests
+                :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx'  'Hdbl' 'Hfl' 'Hcmplx' ⍝ bool requires separate cross tests because of overlap with i1
                     data2←⍎case2
                     desc←testDesc⍬
-                    :If (data≡data2)
-                        r,←assert (((≢data)⍴1) ≡ (data∊data2)) 'tcross0' desc
-                        :Continue
-                    :EndIf
-                    r,←assert (((≢data)⍴0) ≡ (data∊data2)) 'tcross1' desc ⍝ no match, all return 0
-                    r,←assert (((≢data2)⍴0) ≡ (data2∊data)) 'tcross2' desc ⍝ no match, all return 0
-                    r,←assert (((≢data)⍴1) ≡ (data∊data,data2)) 'tcross3' desc ⍝ first data match, returns 1
-                    r,←assert ((((≢data)⍴1),((≢data2)⍴0))≡((data,data2)∊data)) 'tcross4' desc ⍝ data match, data2 no match
-                :EndFor
-                case2←⍬ ⍝ disposing case2 for testDesc
-                desc←testDesc⍬
-
-                ⍝ same type tests
-                r,←assert ((data[?≢data])∊data) 't1' desc                  ⍝ random element is found
-                r,←assert (((((≢data)-1)⍴0), 1)≡data∊(¯1↑data)) 't2' desc  ⍝ All elements return 0 except last
-                r,←assert (((≢data)⍴1)≡data∊data) 't3' desc                ⍝ all elements return 1
-                r,←assert (0≡5E50∊data) 't4' desc                          ⍝ huge element outside set is not found
-
-                ⍝ tests with comparision tolerance
-                d←data[?≢data]
-                :If ct
-                    ⍝ case for CT default
-                    :If (data≡Hdbl) ∨ (data≡Hfl) ∨ (data≡Hcmplx)
-                        ⍝ next number is equal for Hdbl as it comes under the region of tolerant equality
-                        r,←assert (1≡(d∊d+1)) 'CTDefault' desc
+                    :If (83≠type←⎕DR data2) ⍝ special case because of overlap
+                            r,←assert (((≢bool)⍴0) ≡ (bool∊data2)) 'tcrossBool1' desc ⍝ All elements return 0
+                            r,←assert (((≢data2)⍴0) ≡ (data2∊bool)) 'tcrossBool2' desc ⍝ All elements return 0
                     :Else
-                        :Continue ⍝ not relevant for other datatypes
+                        r,←assert (((≢bool)⍴1) ≡ (bool∊data2)) 'tcrossBooli1' desc ⍝ All elements return 1
+                        r,←assert (((⊣,(⌽⊣))((1↓((≢i1)÷2)⍴0),1)) ≡ (data2∊bool)) 'tcrossBooli2' desc ⍝ overlaping 0 1 returns 1
                     :EndIf
-                :Else
-                    :If ((⎕DR data) ∊ 80 160 320 326)
-                        :continue
-                    :EndIf
-                    r,←assert (0≡(d∊d+1)) 'CTZero' desc
-                :EndIf
+                :EndFor
+                ⍝ disposing case for testDesc
+                case←⍬
+                case2←⍬
             :EndFor
-
-            ⍝ Booleans need special tests
-            case←'bool'
-            desc←testDesc⍬
-
-            r,←assert (0∊0) 'tb1' desc
-            r,←assert (~0∊1) 'tb2' desc
-            r,←assert (1 1≡bool∊bool) 'tb3' desc
-            
-            ⍝ Boolean cross type tests
-            :For case2 :In 'i1' 'i2' 'i3' 'char1' 'char2' 'char3' 'ptr' 'dbl' 'fl' 'cmplx'  'Hdbl' 'Hfl' 'Hcmplx' ⍝ bool requires separate cross tests because of overlap with i1
-                data2←⍎case2
-                desc←testDesc⍬
-                :If (83≠type←⎕DR data2) ⍝ special case because of overlap
-                        r,←assert (((≢bool)⍴0) ≡ (bool∊data2)) 'tcrossBool1' desc ⍝ All elements return 0
-                        r,←assert (((≢data2)⍴0) ≡ (data2∊bool)) 'tcrossBool2' desc ⍝ All elements return 0
-                :Else
-                    r,←assert (((≢bool)⍴1) ≡ (bool∊data2)) 'tcrossBooli1' desc ⍝ All elements return 1
-                    r,←assert (((⊣,(⌽⊣))((1↓((≢i1)÷2)⍴0),1)) ≡ (data2∊bool)) 'tcrossBooli2' desc ⍝ overlaping 0 1 returns 1
-                :EndIf
-            :EndFor
-            ⍝ disposing case for testDesc
-            case←⍬
-            case2←⍬
         :EndFor
     ∇
 :EndNamespace


### PR DESCRIPTION
Now all the tests are run 4 times for all datatypes to test for all combinations of (⎕CT ⎕DCT) and ⎕FR totaling 2902 tests for membership.

Todo:

- [x] Investigate why CT default and FR 1287 tests are failing