### PR TITLE
Tests for Residue (R←X|Y)

### DIFF
--- a/docs/decision/primitive-functions/scalar-dyadic-arithmetic.md
+++ b/docs/decision/primitive-functions/scalar-dyadic-arithmetic.md
@@ -1,0 +1,20 @@
+# Scalar Dyadic Arithmetic Functions
+
+## Residue (`R←X|Y`)([docs](http://help.dyalog.com/latest/index.htm#Language/Primitive%20Functions/Residue.htm))
+
+The tests include:
+- Datatype tests: tests for positive and negative for all the available numeric datatypes
+- Tests based on Floating point representation(`⎕FR`): All the tests run with values of `⎕FR` as 645 and 1287.
+- Tests based on Comparison Tollerance(`⎕CT` and `⎕DCT`): All the tests run with default and zero values.
+- Edge Cases:
+    - Separate cases had to be added for 0, ¯1, 0J0, 0.0
+    - Separate cases had to be added to residue propogated using a scan to target certain sections of sources.
+
+Variations include:
+- Normal: general test case with parameter and expected result.
+- Empty: an empty array generated from the parameter of the testcase is used for the test.
+- Different shapes: shapes are randomly generated.
+- Different shapes with 0 in shape: A 0 is randomly inserted into the shape to generate this case.
+
+Code Coverage report: Residue is 100% covered by these tests.
+Significant covered files include: `allos/src/arith_su.c`, `allos/src/z.c`, and `allos/src/scalarscalar.cpp`

--- a/docs/decision/primitive-functions/scalar-monadic.md
+++ b/docs/decision/primitive-functions/scalar-monadic.md
@@ -3,7 +3,7 @@
 ## Magnitude (`R←|Y`)([docs](https://help.dyalog.com/latest/#Language/Primitive%20Functions/Magnitude.htm))
 
 The tests include:
-- Datatype tests: tests for positive and negativefor all the available numeric datatypes
+- Datatype tests: tests for positive and negative for all the available numeric datatypes
 - Tests based on Floating point representation(`⎕FR`): All the tests run with values of `⎕FR` as 645 and 1287.
 - Separate tests for boolean values: Booleans need special tests because construction of boolean arrays is simple and different than others.
 - Edge Cases:

--- a/tests/test_indexof.apln
+++ b/tests/test_indexof.apln
@@ -55,18 +55,18 @@
         ptr←2,/⎕A                                     ⍝ 326: Pointer (32-bit or 64-bit as appropriate)
         dbl←{⍵,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
         cmplx←{⍵,-⍵}(0J1×⍳100)+⌽⍳100                  ⍝ 1289: 128 bits Complex
-        ⍝ Hdbl is 645 but higher order to test for CT value
+        ⍝ Hdbl is 645 but larger numbers to test for CT value
         ⍝ intervals of 2 are chosen because CT for these numbers +1 and -1
         ⍝ come under the region of tolerant equality
         Hdbl←{⍵,-⍵}1E15+(1E10×⍳50)
-        ⍝ Hfl is 1287 but higher order to test for CT value
+        ⍝ Hfl is 1287 but larger numbers to test for CT value
         ⍝ far intervals are chosen for non overlap 
         ⍝ with region of tolerant equality
         ⎕FR←fr_decf
         fl←{⍵,-⍵}i3+0.01                              ⍝ 1287: 128 bits Decimal
         Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
         ⎕FR←fr_dbl
-        Hcmplx←{⍵,-⍵}(1E14J1E14×⍳20)                  ⍝ 1289 but higher order to test for CT value
+        Hcmplx←{⍵,-⍵}(1E14J1E14×⍳20)                  ⍝ 1289 but larger numbers to test for CT value
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR, '& ⎕IO:', ⎕IO}

--- a/tests/test_magnitude.apln
+++ b/tests/test_magnitude.apln
@@ -40,10 +40,10 @@
         i2←{⍵,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
         i3←{⍵,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
         dbl←{⍵,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
-        ⍝ Hdbl and Sdbl is 645 but higher order and lower order
+        ⍝ Hdbl and Sdbl is 645 but larger and smaller numbers
         Hdbl←{⍵,-⍵}1E14+(2×⍳50)
         Sdbl←{⍵,-⍵}(⍳10)×1E¯40
-        ⍝ Hfl and Sfl is 1287 but higher order and lower order
+        ⍝ Hfl and Sfl is 1287 but larger and smaller numbers
         ⎕FR←fr_decf                                   ⍝ use ⎕FR=1287
         fl←{⍵,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
         Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
@@ -85,7 +85,7 @@
     ∇ r←Test_Magnitude_Cmplx ;cmplx;Hcmplx;magCmplx;d;case;data;testDesc;desc
         i1←{⍵}⍳120                                    ⍝ 83: 8 bits signed integer
         cmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
-        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E13J1E13×⍳20)     ⍝ 1289 but higher order
+        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E13J1E13×⍳20)     ⍝ 1289 but larger numbers
         ⍝ DECF in cmplx numbers are not recommended to be used by the docs
         fr_dbl←645
         fr_decf←1287

--- a/tests/test_membership.apln
+++ b/tests/test_membership.apln
@@ -57,12 +57,12 @@
         ptr←2,/⎕A                                     ⍝ 326: Pointer (32-bit or 64-bit as appropriate)
         dbl←{⍵,-⍵}i3+0.1                              ⍝ 645: 64 bits Floating
         cmplx←{⍵,-⍵}(0J1×⍳100)+⌽⍳100                  ⍝ 1289: 128 bits Complex
-        Hcmplx←{⍵,-⍵}(1E14J1E14×⍳20)                  ⍝ 1289 but higher order to test for CT value
-        ⍝ Hdbl is 645 but higher order to test for CT value
+        Hcmplx←{⍵,-⍵}(1E14J1E14×⍳20)                  ⍝ 1289 but larger numbers to test for CT value
+        ⍝ Hdbl is 645 but larger numbers to test for CT value
         ⍝ intervals of 2 are chosen because CT for these numbers +1 and -1
         ⍝ come under the region of tolerant equality
         Hdbl←{⍵,-⍵}1E14+(2×⍳50)
-        ⍝ Hfl is 1287 but higher order to test for CT value
+        ⍝ Hfl is 1287 but larger numbers to test for CT value
         ⍝ far intervals are chosen for non overlap 
         ⍝ with region of tolerant equality
         ⎕FR←fr_decf

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -75,10 +75,6 @@
                 ⍝ simple, non-simple so scalar and vector arguments with fewer than 8 elements (RSLT.bound < 8 )
                 r,←'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
                 r,←'Ti6' desc Assert (2/0)≡(2|2/1E40)
-                
-                ⍝ r,←'Ti8' desc Assert (⍬)≡(⍬|11)
-                ⍝ r,←'Ti9' desc Assert (,⍬)≡,(''|11)
-                ⍝ r,←'tb3' desc Assert (1)≡((∧/1 0 1 0)|(∧/1 1 1 1))
 
                 :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
@@ -105,6 +101,7 @@
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
                     r,←'T2' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+                    r,←'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data) 
 
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -30,7 +30,7 @@
         tRes,←('ShapeW0',tID) tCmt Assert (shapeW0⍴0) ≡ actualRSW0
     ∇
 
-    ∇ r←Test_Residue ;genResidue;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
+    ∇ r←Test_Residue ;genResidue;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;almostd1;fltalmostd1;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
         ct_default←1E¯14
         dct_default←1E¯28
         fr_dbl←645
@@ -113,8 +113,8 @@
                         r,← 'TSeqDbl2' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,9.5}halfLen⍴(0.5+⍳9), 0.5) 10 data       ⍝ Sequences to test functionality of residue
                     :EndIf
 
-                    almostd1←d1×+/10⍴0.1 ⍝ Almost, but not exactly d1
                     ⍝ tests with comparision tolerance
+                    almostd1←d1×+/10⍴0.1 ⍝ Almost, but not exactly d1
                     :If ct ⍝ tolerant
                         :If (⊂data)∊Hdbl Hfl Hcmplx
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
@@ -126,10 +126,18 @@
                     :Else  ⍝ exact
                         :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
                             d1←{(⍵≡¯1)∨(⍵≡0)∨(⍵≡1):data[?≢data]⋄⍵}d1
+
                             ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
                             r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
-                            r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (fr=2) ∨ (fr=1 ∧ case≡'Hfl')
-                            r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨ (fr=2) ∨ (fr=1 ∧ case≡'Hfl')
+
+                            :If fr=2
+                                fltalmostd1←d1×1-1E¯30 ⍝ infinitesimally close to d1
+                                r,← 'CTZeroAlmost1fr2' desc Assert (0≡⌊|fltalmostd1|d1) ∨ (1289≡⎕dr data)
+                                r,← 'CTZeroAlmost2fr2' desc Assert ((⌈|d1)≡⌈|d1|fltalmostd1) ∨ (1289≡⎕dr data)
+                            :Else
+                                r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ case≡'Hfl'
+                                r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨  case≡'Hfl'
+                            :EndIf
                         :EndIf
                     :EndIf
                 :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -6,7 +6,7 @@
     Assert←#.unittest.Assert
 
     ⍝ Run Variations of each test with normal, empty and multiple shaped data
-    ∇ tRes←tData RunVariations exp ;actualR;actualRE;expectedR;larg;rarg;res;tID;tCmt;lshape;lshapeW0;rshape;x;actualRM
+    ∇ tRes←tData RunVariations exp ;actualR;actualRE;expectedR;larg;rarg;res;tID;tCmt;shape;actualRS;shapeW0;actualRSW0
         (expectedR larg rarg)←exp
         (tID tCmt)←tData
         tRes←⍬
@@ -18,6 +18,16 @@
         ⍝ empty
         actualRE←(0⍴larg)|(0⍴rarg) ⍝ 0 in the shape means we have no elements in the array, i.e. it's empty.
         tRes,←('EmptyL',tID) tCmt Assert ⍬≡actualRE ⍝ empty array is expectedR
+    
+        ⍝ different shapes
+        shape←?(?4)/4
+        actualRS←(shape⍴larg)|(shape⍴rarg)
+        tRes,←('Multiple',tID) tCmt Assert (shape⍴expectedR)≡actualRS
+
+        ⍝ different shapes with 0 in shape
+        shapeW0←(0@(?(≢shape)))shape
+        actualRSW0←(shapeW0⍴larg)|(shapeW0⍴rarg)
+        tRes,←('ShapeW0',tID) tCmt Assert (shapeW0⍴0) ≡ actualRSW0
     ∇
 
     ∇ r←Test_Residue ;w;n;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
@@ -42,7 +52,6 @@
         ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
         cmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
         Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E13J1E13×⍳20)     ⍝ 1289 but higher order
-
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -72,9 +72,9 @@
                 r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1             ⍝ Separate case for larg=0J0
                 r,← 'Ti4' desc RunVariations ((,0, 1E10) genResidue 10) (,0 1E10) (10)  ⍝ Separate case for larg=0.0
 
-                ⍝ simple, non-simple so scalar and vector arguments with fewer than 8 elements (RSLT.bound < 8 )
-                r,←'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
-                r,←'Ti6' desc Assert (2/0)≡(2|2/1E40)
+                ⍝ Using scan to target specific cases
+                r,← 'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
+                r,← 'Ti6' desc Assert (2/0)≡(2|2/1E40)
 
                 :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
@@ -97,11 +97,11 @@
                     case2←⍬ ⍝ disposing case2 for testDesc
                     desc←testDesc⍬
 
-                    r,←'T1' desc RunVariations (data genResidue ⌽data) data (⌽data) ⍝ custom func finds results on array
+                    r,← 'T1' desc RunVariations (data genResidue ⌽data) data (⌽data) ⍝ custom func finds results on array
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
-                    r,←'T2' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
-                    r,←'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data) 
+                    r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+                    r,← 'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data) 
 
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -67,11 +67,10 @@
                 case←'independant'
                 case2←⍬
                 desc←testDesc⍬
-                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11                 ⍝ Separate case for larg=0
-                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) (¯1) 11             ⍝ Separate case for larg=¯1
-                r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1         ⍝ Separate case for larg=0J0
-                
-                ⍝ r,← 'Ti4' desc RunVariations ((,0.0) genResidue 11) (,0.0) (11)
+                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11                     ⍝ Separate case for larg=0
+                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) (¯1) 11                 ⍝ Separate case for larg=¯1
+                r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1             ⍝ Separate case for larg=0J0
+                r,← 'Ti4' desc RunVariations ((,0, 1E10) genResidue 10) (,0 1E10) (10)  ⍝ Separate case for larg=0.0
 
                 ⍝ simple, non-simple so scalar and vector arguments with fewer than 8 elements (RSLT.bound < 8 )
                 r,←'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -67,13 +67,16 @@
                 case←'independant'
                 case2←⍬
                 desc←testDesc⍬
-                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11
-                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) (¯1) 11
-                r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1
+                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11                 ⍝ Separate case for larg=0
+                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) (¯1) 11             ⍝ Separate case for larg=¯1
+                r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1         ⍝ Separate case for larg=0J0
+                
                 ⍝ r,← 'Ti4' desc RunVariations ((,0.0) genResidue 11) (,0.0) (11)
-                r,← 'Ti5' desc RunVariations (1J1 genResidue 11) (1J1) (11)
-                r,←'Ti6' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
-                r,←'Ti7' desc Assert (2/0)≡(2|2/1E40)
+
+                ⍝ simple, non-simple so scalar and vector arguments with fewer than 8 elements (RSLT.bound < 8 )
+                r,←'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
+                r,←'Ti6' desc Assert (2/0)≡(2|2/1E40)
+                
                 ⍝ r,←'Ti8' desc Assert (⍬)≡(⍬|11)
                 ⍝ r,←'Ti9' desc Assert (,⍬)≡,(''|11)
                 ⍝ r,←'tb3' desc Assert (1)≡((∧/1 0 1 0)|(∧/1 1 1 1))
@@ -100,10 +103,9 @@
                     desc←testDesc⍬
 
                     r,←'T1' desc RunVariations (data genResidue ⌽data) data (⌽data) ⍝ custom func finds results on array
-                    ⍝ r,←'T2' desc RunVariations (0⍨¨data) data data ⍝ all are perfectly divisible
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
-                    r,←'T3' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+                    r,←'T2' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
 
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -36,7 +36,7 @@
         fr_dbl←645
         fr_decf←1287
 
-        bool←0 1                                      ⍝ 11: 1 bit Boolean type arrays
+        bool←0 1                                        ⍝ 11: 1 bit Boolean type arrays
         i1←{⍵,0,-⍵}⍳120                                 ⍝ 83: 8 bits signed integer
         i2←{⍵,0,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
         i3←{⍵,0,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
@@ -44,12 +44,12 @@
         ⍝ Hdbl is 645 but higher order
         Hdbl←{⍵,-⍵}1E14+(2×⍳50)
         ⍝ Hfl is 1287 but higher order
-        ⎕FR←fr_decf                                   ⍝ use ⎕FR=1287
+        ⎕FR←fr_decf                                     ⍝ use ⎕FR=1287
         fl←{⍵,0,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
-        Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
-        ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
+        Hfl←{⍵,-⍵}2E29+(1E16×⍳10)                       ⍝ 1287 but higher order
+        ⎕FR←fr_dbl                                      ⍝ revert ⎕FR=645
         cmplx←{(-⍵),⍵,0,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
-        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E14J1E14×⍳20)     ⍝ 1289 but higher order
+        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E14J1E14×⍳20)       ⍝ 1289 but higher order
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
@@ -98,8 +98,7 @@
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
                     r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2                                ⍝ custom func finds results on single element
-                    r,← 'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data)
-                    r,← 'T4' desc RunVariations (0⍨¨data) 1 (⌊data)                                     ⍝ check remainder with 1 with defined output
+                    r,← 'T3' desc RunVariations (0⍨¨data) 1 (⌊data)                                     ⍝ check remainder with 1 result is a defined output
 
                     :If (⎕DR data)∊83 163 323
                         halfLen←(¯1+≢data)÷2
@@ -120,7 +119,7 @@
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
                             r,← 'CTDefault' desc Assert ((0≡(d1|d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
                         :Else
-                            r,← 'CTDefaultAlmost1' desc Assert 0≡d1|almostd1
+                            r,← 'CTDefaultAlmost1' desc Assert 0≡d1|almostd1                                    ⍝ both are treated equally
                             r,← 'CTDefaultAlmost2' desc Assert 0≡almostd1|d1
                         :EndIf
                     :Else  ⍝ exact
@@ -128,14 +127,16 @@
                             d1←{(⍵≡¯1)∨(⍵≡0)∨(⍵≡1):data[?≢data]⋄⍵}d1
 
                             ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
-                            r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
+                            r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))                      ⍝ not in the tollerant range
 
                             :If fr=2
                                 fltalmostd1←d1×1-1E¯30 ⍝ infinitesimally close to d1
-                                r,← 'CTZeroAlmost1fr2' desc Assert (0≡⌊|fltalmostd1|d1) ∨ (1289≡⎕dr data)
-                                r,← 'CTZeroAlmost2fr2' desc Assert ((⌈|d1)≡⌈|d1|fltalmostd1) ∨ (1289≡⎕dr data)
+                                r,← 'CTZeroFltAlmost1' desc Assert (0≡⌊|fltalmostd1|d1) ∨ (1289≡⎕dr data)       ⍝ in the tollerant range
+                                r,← 'CTZeroFltAlmost2' desc Assert ((⌈|d1)≡⌈|d1|fltalmostd1) ∨ (1289≡⎕dr data)
+                                r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (1289≡⎕dr data)             ⍝ not in the tollerant range
+                                r,← 'CTZeroAlmost2' desc Assert (0≡⌈|d1|almostd1) ∨ (1289≡⎕dr data)
                             :Else
-                                r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ case≡'Hfl'
+                                r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ case≡'Hfl'                  ⍝ in the tollerant range
                                 r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨  case≡'Hfl'
                             :EndIf
                         :EndIf

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -1,0 +1,37 @@
+⍝ This Namespace includes tests for the function Residue which is represented by Dyadic stile(|)
+⍝
+⍝ Residue (R←X|Y)
+⍝ Residue is a dyadic scalar function which gives the remainder of division between two real numbers. It takes the divisor as the left argument, and the dividend as the right argument.
+:Namespace test_residue
+    Assert←#.unittest.Assert
+
+    ⍝ Run Variations of each test with normal, empty and multiple shaped data
+    ∇ tRes←tData RunVariations exp ;actualR;actualRE;expectedR;larg;rarg;res;tID;tCmt;lshape;lshapeW0;rshape;x;actualRM
+        (expectedR larg rarg)←exp
+        (tID tCmt)←tData
+        tRes←⍬
+
+        ⍝ normal
+        actualR←larg|rarg
+        tRes,←tData Assert expectedR≡actualR
+    ∇
+
+    ⍝ Read more about DR: https://help.dyalog.com/latest/#Language/System%20Functions/Data%20Representation%20Monadic.htm
+    ⍝ Read more about CT and DCT: https://help.dyalog.com/latest/#Language/System%20Functions/ct.htm
+    ∇ r←Test_Membership ;w;n;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
+        ct_default←1E¯14
+        dct_default←1E¯28
+        fr_dbl←645
+        fr_decf←1287
+
+        r←⍬
+        testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
+
+        genResidue←{⍵-⍺×⌊⍵÷⍺+0=⍺}
+        case←⍬
+        case2←⍬
+        desc←testDesc⍬
+        r,← 'TB1' desc RunVariations (5 genResidue 11) 5 11
+    ∇
+
+:EndNamespace

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -98,7 +98,8 @@
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
                     r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2                                ⍝ custom func finds results on single element
-                    r,← 'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data) 
+                    r,← 'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data)
+                    r,← 'T4' desc RunVariations (0⍨¨data) 1 (⌊data)                                     ⍝ check remainder with 1 with defined output
 
                     :If (⎕DR data)∊83 163 323
                         halfLen←(¯1+≢data)÷2
@@ -124,7 +125,7 @@
                         :EndIf
                     :Else  ⍝ exact
                         :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
-                            d1←{d1=¯1:data[?≢data]⋄d1}d1
+                            d1←{(⍵≡¯1)∨(⍵≡0)∨(⍵≡1):data[?≢data]⋄⍵}d1
                             ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
                             r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
                             r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (fr=2) ∨ (fr=1 ∧ case≡'Hfl')

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -24,10 +24,62 @@
         fr_dbl←645
         fr_decf←1287
 
+        bool←0 1                                      ⍝ 11: 1 bit Boolean type arrays
+        i1←{⍵,-⍵}⍳120                                 ⍝ 83: 8 bits signed integer
+        i2←{⍵,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
+        i3←{⍵,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
+        dbl←{⍵,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
+        ⍝ Hdbl and Sdbl is 645 but higher order and lower order
+        Hdbl←{⍵,-⍵}1E14+(2×⍳50)
+        Sdbl←{⍵,-⍵}(⍳10)×1E¯40
+        ⍝ Hfl and Sfl is 1287 but higher order and lower order
+        ⎕FR←fr_decf                                   ⍝ use ⎕FR=1287
+        fl←{⍵,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
+        Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
+        Sfl←{⍵,-⍵}(⍳10)×1E¯40
+        ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
+
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
 
         genResidue←{⍵-⍺×⌊⍵÷⍺+0=⍺}
+        
+        case←⍬
+        case2←⍬
+
+        :For ct :In 1 0 
+            (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
+            :For fr :In 2 1
+                ⎕FR←fr⊃fr_dbl fr_decf
+
+                :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl'
+                    data←⍎case
+                    :If ⎕FR=fr_decf ∧ 1289=⎕DR data ⍝ ⎕FR=1287 is not recommended to be used with cmplx
+                        :Continue
+                    :EndIf
+                    ⍝ Cross type tests
+                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl'
+                        data2←⍎case2
+                        desc←testDesc⍬
+                        :If (data≡data2)
+                            r,←'TCross0' desc RunVariations (0⍨¨data) data data2
+                            :Continue
+                        :EndIf
+                        ⍝ r,← 'TCross1' desc RunVariations (data genResidue data2) data data2                    ⍝ no match, all return 0
+                        ⍝ r,← 'TCross2' desc RunVariations (data2 genResidue data) data2 data                    ⍝ no match, all return 0
+                    :EndFor
+
+                    case2←⍬ ⍝ disposing case2 for testDesc
+                    desc←testDesc⍬
+
+                    r,←'T1' desc RunVariations (data genResidue ⌽data) data (⌽data) ⍝ custom func finds results on array
+                    ⍝ r,←'T2' desc RunVariations (0⍨¨data) data data ⍝ all are perfectly divisible
+                    d1←data[?≢data]
+                    d2←data[?≢data]
+                    r,←'T3' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+                :EndFor
+            :EndFor
+        :EndFor
         case←⍬
         case2←⍬
         desc←testDesc⍬

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -106,10 +106,10 @@
                         r,← 'TSeq2' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(⍳9), 0) 10 data              ⍝ Sequences to test functionality of residue
                     :EndIf
 
-                    :If (⎕DR data)∊645
+                    :If case≡'dbl'
                         halfLen←(¯1+≢data)÷2
-                        ⍝ todo: for some reason does not work(domain error) the first time i run it but works everytime after
-                        r,← 'TSeqDbl1' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(1.5 2.5 3.5 0.5)) 4 data    ⍝ Sequences to test functionality of residue
+                        r,← 'TSeqDbl1' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,3.5}halfLen⍴(1.5 2.5 3.5 0.5)) 4 data    ⍝ Sequences to test functionality of residue
+                        r,← 'TSeqDbl2' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,9.5}halfLen⍴(0.5+⍳9), 0.5) 10 data       ⍝ Sequences to test functionality of residue
                     :EndIf
 
                     almostd1←d1×+/10⍴0.1
@@ -129,7 +129,7 @@
                             d1←{d1=¯1:data[?≢data]⋄d1}d1
                             r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
                             r,← 'CTZeroAlmost1' desc Assert (0≢d1|almostd1) ∨ (fr=2) ⍝ todo: figure out how to make it work for 128bit
-                            r,← 'CTZeroAlmost2' desc Assert (0≢almostd1|d1) ∨ (fr=2)
+                            r,← 'CTZeroAlmost2' desc Assert (0≢almostd1|d1) ∨ (fr=2) ⍝ still has some issues need to figure out
                         :EndIf
                     :EndIf
                 :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -63,7 +63,7 @@
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
             :For fr :In 2 1
                 ⎕FR←fr⊃fr_dbl fr_decf
-                
+
                 ⍝ Tests added to achieve complete code coverage
                 case←'independant'
                 case2←⍬
@@ -113,7 +113,7 @@
                     :EndIf
 
                     ⍝ tests with comparision tolerance
-                    almostd1←d1×1-fr⊃1E¯16 1E¯30
+                    almostd1←d1×1-fr⊃1E¯2×ct_default dct_default
                     :If ct ⍝ tolerant
                         :If (⊂data)∊Hdbl Hfl Hcmplx
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -112,7 +112,7 @@
                         r,← 'TSeqDbl2' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,9.5}halfLen⍴(0.5+⍳9), 0.5) 10 data       ⍝ Sequences to test functionality of residue
                     :EndIf
 
-                    almostd1←d1×+/10⍴0.1
+                    almostd1←d1×+/10⍴0.1 ⍝ Almost, but not exactly d1
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant
                         :If (⊂data)∊Hdbl Hfl Hcmplx
@@ -122,14 +122,13 @@
                             r,← 'CTDefaultAlmost1' desc Assert 0≡d1|almostd1
                             r,← 'CTDefaultAlmost2' desc Assert 0≡almostd1|d1
                         :EndIf
-
                     :Else  ⍝ exact
                         :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
-                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
                             d1←{d1=¯1:data[?≢data]⋄d1}d1
+                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
                             r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
-                            r,← 'CTZeroAlmost1' desc Assert (0≢d1|almostd1) ∨ (fr=2) ⍝ todo: figure out how to make it work for 128bit
-                            r,← 'CTZeroAlmost2' desc Assert (0≢almostd1|d1) ∨ (fr=2) ⍝ still has some issues need to figure out
+                            r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (fr=2) ∨ (fr=1 ∧ case≡'Hfl')
+                            r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨ (fr=2) ∨ (fr=1 ∧ case≡'Hfl')
                         :EndIf
                     :EndIf
                 :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -54,7 +54,7 @@
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
 
-        genResidue←{⍵-⍺×⌊⍵÷⍺+0=⍺}
+        genResidue←{⍵-⍺×⌊⍵÷⍺+⍺=0}
         
         case←⍬
         case2←⍬
@@ -81,15 +81,19 @@
                 :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
                     ⍝ Cross type tests
-                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx'
+                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'fl'
                         data2←⍎case2
+                        :If (⊂data)∊cmplx Hdbl Hfl Hcmplx
+                            :Continue
+                        :EndIf
                         desc←testDesc⍬
                         :If (data≡data2)
                             r,←'TCross0' desc RunVariations (0⍨¨data) data data2
                             :Continue
                         :EndIf
-                        ⍝ r,← 'TCross1' desc RunVariations (data genResidue data2) data data2                    ⍝ no match, all return 0
-                        ⍝ r,← 'TCross2' desc RunVariations (data2 genResidue data) data2 data                    ⍝ no match, all return 0
+                        data2←(≢data)↑data2 ⍝ strip data2 to be equal length to data
+                        r,← 'TCross1' desc RunVariations (data genResidue data2) data data2
+                        r,← 'TCross2' desc RunVariations (data2 genResidue data) data2 data
                     :EndFor
 
                     case2←⍬ ⍝ disposing case2 for testDesc

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -14,6 +14,10 @@
         ⍝ normal
         actualR←larg|rarg
         tRes,←tData Assert expectedR≡actualR
+        
+        ⍝ empty
+        actualRE←(0⍴larg)|(0⍴rarg) ⍝ 0 in the shape means we have no elements in the array, i.e. it's empty.
+        tRes,←('EmptyL',tID) tCmt Assert ⍬≡actualRE ⍝ empty array is expectedR
     ∇
 
     ∇ r←Test_Residue ;w;n;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -16,9 +16,7 @@
         tRes,←tData Assert expectedR≡actualR
     ∇
 
-    ⍝ Read more about DR: https://help.dyalog.com/latest/#Language/System%20Functions/Data%20Representation%20Monadic.htm
-    ⍝ Read more about CT and DCT: https://help.dyalog.com/latest/#Language/System%20Functions/ct.htm
-    ∇ r←Test_Membership ;w;n;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
+    ∇ r←Test_Residue ;w;n;r;data;case;data2;case2;type;bool;i1;char1;char2;i2;char3;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
         ct_default←1E¯14
         dct_default←1E¯28
         fr_dbl←645
@@ -50,7 +48,7 @@
         case←⍬
         case2←⍬
 
-        :For ct :In 1 0 
+        :For ct :In 0 1
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
             :For fr :In 2 1
                 ⎕FR←fr⊃fr_dbl fr_decf
@@ -77,6 +75,18 @@
                     d1←data[?≢data]
                     d2←data[?≢data]
                     r,←'T3' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+                    ⍝ tests with comparision tolerance
+                    :If ct ⍝ tolerant
+                        :If (⊂data)∊Hdbl Hfl Hcmplx
+                            ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
+                            r,← 'CTDefault' desc Assert ((1≡(d1∊d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
+                        :EndIf
+                    :Else  ⍝ exact
+                        :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
+                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
+                            r,← 'CTZero' desc Assert ((0≡(d1∊d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
+                        :EndIf
+                    :EndIf
                 :EndFor
             :EndFor
         :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -70,10 +70,8 @@
                 desc←testDesc⍬
                 r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11        ⍝ Special optimization for scalar 0 from iresidue at apl/allos/src/scalarscalar.cpp#L518
                 r,← 'Ti2' desc RunVariations (¯1 genResidue 11) ¯1 11      ⍝ Special optimization for scalar ¯1 from iresidue at apl/allos/src/scalarscalar.cpp#L518
-
-                ⍝ Using scan to target specific cases
-                r,← 'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
-                r,← 'Ti6' desc Assert (2/0)≡(2|2/1E40)
+                r,← 'Ti3' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)     ⍝ Special optimization for scans from code around apl/allos/src/arith_su.c#L1241
+                r,← 'Ti4' desc Assert (2/0)≡(2|2/1E40)                     ⍝ Special optimization for scans from code around apl/allos/src/arith_su.c#L1241
 
                 :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
@@ -88,7 +86,7 @@
                             r,←'TCross0' desc RunVariations (0⍨¨data) data data2
                             :Continue
                         :EndIf
-                        data2←(≢data)↑data2 ⍝ strip data2 to be equal length to data
+                        data2←(≢data)↑data2                                                             ⍝ strip data2 to be equal length to data
                         r,← 'TCross1' desc RunVariations (data genResidue data2) data data2
                         r,← 'TCross2' desc RunVariations (data2 genResidue data) data2 data
                     :EndFor
@@ -96,22 +94,23 @@
                     case2←⍬ ⍝ disposing case2 for testDesc
                     desc←testDesc⍬
 
-                    r,← 'T1' desc RunVariations (data genResidue ⌽data) data (⌽data) ⍝ custom func finds results on array
+                    r,← 'T1' desc RunVariations (data genResidue ⌽data) data (⌽data)                    ⍝ custom func finds results on array
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
-                    r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+                    r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2                                ⍝ custom func finds results on single element
                     r,← 'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data) 
 
-                    ⍝ :If (⎕DR data)∊83 163 323
-                    ⍝     halfLen←(≢data)÷2
-                    ⍝     r,← 'TSeq1' desc RunVariations ({⍵,(1↓⌽⍵),0}halfLen⍴1 2 3 0) 4 data ⍝ Sequences to test functionality of residue
-                    ⍝     r,← 'TSeq2' desc RunVariations ({⍵,(1↓⌽⍵),0}halfLen⍴(⍳9),0) 10 data ⍝ Sequences to test functionality of residue
-                    ⍝ :EndIf
+                    :If (⎕DR data)∊83 163 323
+                        halfLen←(¯1+≢data)÷2
+                        r,← 'TSeq1' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴1 2 3 0) 4 data               ⍝ Sequences to test functionality of residue
+                        r,← 'TSeq2' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(⍳9), 0) 10 data              ⍝ Sequences to test functionality of residue
+                    :EndIf
 
-                    ⍝ :If (⎕DR data)∊645
-                    ⍝ halfLen←(≢data)÷2
-                    ⍝     ⍝ r,← 'TSeq1' desc RunVariations ({⍵,(1↓⌽⍵),0}halfLen⍴1.5 2.5 3.5 0.5) 4 data ⍝ Sequences to test functionality of residue
-                    ⍝ :EndIf
+                    :If (⎕DR data)∊645
+                        halfLen←(¯1+≢data)÷2
+                        ⍝ todo: for some reason does not work(domain error) the first time i run it but works everytime after
+                        r,← 'TSeqDbl1' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(1.5 2.5 3.5 0.5)) 4 data    ⍝ Sequences to test functionality of residue
+                    :EndIf
 
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant
@@ -122,6 +121,7 @@
                     :Else  ⍝ exact
                         :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
                             ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
+                            ⍝ d1←{d1=¯1:data[?≢data]⋄d1}d1
                             r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
                         :EndIf
                     :EndIf

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -54,10 +54,7 @@
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
 
-        genResidue←{⍵-⍺×⌊⍵÷⍺+⍺=0}
-        
-        case←⍬
-        case2←⍬
+        genResidue←{⍵-⍺×⌊⍵÷⍺+⍺=0} ⍝ Generator function for residue
 
         :For ct :In 0 1
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
@@ -94,44 +91,42 @@
                     case2←⍬ ⍝ disposing case2 for testDesc
                     desc←testDesc⍬
 
-                    r,← 'T1' desc RunVariations (data genResidue ⌽data) data (⌽data)                    ⍝ custom func finds results on array
+                    r,← 'T1' desc RunVariations (data genResidue ⌽data) data (⌽data)                    ⍝ generator func finds results on array
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
-                    r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2                                ⍝ custom func finds results on single element
+                    r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2                                ⍝ generator func finds results on single element
                     r,← 'T3' desc RunVariations (0⍨¨data) 1 (⌊data)                                     ⍝ check remainder with 1 result is a defined output
 
-                    :If (⎕DR data)∊83 163 323
+                    :If (⊂data)∊i1 i2 i3
                         halfLen←(¯1+≢data)÷2
-                        r,← 'TSeq1' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴1 2 3 0) 4 data               ⍝ Sequences to test functionality of residue
-                        r,← 'TSeq2' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(⍳9), 0) 10 data              ⍝ Sequences to test functionality of residue
+                        r,← 'TSeq2' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(⍳9), 0) 10 data              ⍝ sequences to test functionality of residue
+                        r,← 'TSeq1' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴1 2 3 0) 4 data               ⍝ remainder sequence is ⍳(N-1), 0
                     :EndIf
 
                     :If case≡'dbl'
                         halfLen←(¯1+≢data)÷2
-                        r,← 'TSeqDbl1' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,3.5}halfLen⍴(1.5 2.5 3.5 0.5)) 4 data    ⍝ Sequences to test functionality of residue
-                        r,← 'TSeqDbl2' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,9.5}halfLen⍴(0.5+⍳9), 0.5) 10 data       ⍝ Sequences to test functionality of residue
+                        r,← 'TSeqDbl1' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,3.5}halfLen⍴(1.5 2.5 3.5 0.5)) 4 data    ⍝ sequences to test functionality of residue
+                        r,← 'TSeqDbl2' desc RunVariations ({⍵,0,(2↓⌽⍵),0.5,9.5}halfLen⍴(0.5+⍳9), 0.5) 10 data       ⍝ sequences to test functionality of residue
                     :EndIf
 
                     ⍝ tests with comparision tolerance
-                    almostd1←d1×1-fr⊃1E¯2×ct_default dct_default
+                    almostd1←d1×1-fr⊃1E¯2×ct_default dct_default ⍝ infinitesimally close to d1 but smaller
                     :If ct ⍝ tolerant
-                        :If (⊂data)∊Hdbl Hfl Hcmplx
+                        :If (⊂data)∊Hdbl Hfl Hcmplx ⍝ bigger numbers
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
                             r,← 'CTDefault' desc Assert ((0≡(d1|d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
-                        :Else
-                            r,← 'CTDefaultAlmost1' desc Assert 0≡d1|almostd1                                    ⍝ both are treated equally
-                            r,← 'CTDefaultAlmost2' desc Assert 0≡almostd1|d1
+                        :Else ⍝ other than bigger numbers
+                            r,← 'CTDefaultAlmost1' desc Assert 0≡d1|almostd1 ⍝ No difference because tolerantly equal
+                            r,← 'CTDefaultAlmost2' desc Assert 0≡almostd1|d1 ⍝ Same as above but flipped
                         :EndIf
-                    :Else  ⍝ exact
-                        :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
-                            d1←{(⍵≡¯1)∨(⍵≡0)∨(⍵≡1):data[?≢data]⋄⍵}d1
+                    :Else ⍝ exact
+                        ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
+                        ⍝ if cmplx then generator function elseif negative then ⍵+1 else 1 because of 0 tolerance
+                        r,← 'CTZero' desc Assert (({⊢≠+⍵:d1 genResidue d1+1⋄1+0≤⍵⊃⍵+1 1}d1)≡d1|d1+1) ∨ (fr=1 ∧ case≡'Hfl')
 
-                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
-                            r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))                                          ⍝ not in the tollerant range
-
-                            r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨  (fr=1 ∧ case≡'Hfl')                                ⍝ in the tollerant range
-                            r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨  (fr=1 ∧ case≡'Hfl') ∨ (fr=2 ∧ 1289≡⎕dr data)
-                        :EndIf
+                        ⍝ |, ⌈ and ⌊ are added to it for getting a fixed result
+                        r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (fr=1 ∧ case≡'Hfl')
+                        r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨ (fr=1 ∧ case≡'Hfl') ∨ (fr=2 ∧ 1289≡⎕dr data)
                     :EndIf
                 :EndFor
             :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -113,7 +113,7 @@
                     :EndIf
 
                     ⍝ tests with comparision tolerance
-                    almostd1←{fr=1:⍵×+/10⍴0.1⋄⍵×1-1E¯30}d1 ⍝ Almost, but not exactly d1
+                    almostd1←d1×1-fr⊃1E¯16 1E¯30
                     :If ct ⍝ tolerant
                         :If (⊂data)∊Hdbl Hfl Hcmplx
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -70,7 +70,7 @@
                 case2←⍬
                 desc←testDesc⍬
                 r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11
-                r,← 'Ti2' desc RunVariations (-1 genResidue 11) (-1) 11
+                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) (¯1) 11
                 r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1
                 ⍝ r,← 'Ti4' desc RunVariations ((,0.0) genResidue 11) (,0.0) (11)
                 r,← 'Ti5' desc RunVariations (1J1 genResidue 11) (1J1) (11)

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -38,6 +38,9 @@
         Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
         Sfl←{⍵,-⍵}(⍳10)×1E¯40
         ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
+        cmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
+        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E13J1E13×⍳20)     ⍝ 1289 but higher order
+
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
@@ -52,13 +55,10 @@
             :For fr :In 2 1
                 ⎕FR←fr⊃fr_dbl fr_decf
 
-                :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl'
+                :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
-                    :If ⎕FR=fr_decf ∧ 1289=⎕DR data ⍝ ⎕FR=1287 is not recommended to be used with cmplx
-                        :Continue
-                    :EndIf
                     ⍝ Cross type tests
-                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl'
+                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl' 'cmplx' 'Hcmplx'
                         data2←⍎case2
                         desc←testDesc⍬
                         :If (data≡data2)

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -112,17 +112,24 @@
                         r,← 'TSeqDbl1' desc RunVariations ({⍵,(⌽⍵),0}halfLen⍴(1.5 2.5 3.5 0.5)) 4 data    ⍝ Sequences to test functionality of residue
                     :EndIf
 
+                    almostd1←d1×+/10⍴0.1
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant
                         :If (⊂data)∊Hdbl Hfl Hcmplx
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
                             r,← 'CTDefault' desc Assert ((0≡(d1|d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
+                        :Else
+                            r,← 'CTDefaultAlmost1' desc Assert 0≡d1|almostd1
+                            r,← 'CTDefaultAlmost2' desc Assert 0≡almostd1|d1
                         :EndIf
+
                     :Else  ⍝ exact
                         :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
                             ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
-                            ⍝ d1←{d1=¯1:data[?≢data]⋄d1}d1
+                            d1←{d1=¯1:data[?≢data]⋄d1}d1
                             r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
+                            r,← 'CTZeroAlmost1' desc Assert (0≢d1|almostd1) ∨ (fr=2) ⍝ todo: figure out how to make it work for 128bit
+                            r,← 'CTZeroAlmost2' desc Assert (0≢almostd1|d1) ∨ (fr=2)
                         :EndIf
                     :EndIf
                 :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -37,18 +37,18 @@
         fr_decf←1287
 
         bool←0 1                                      ⍝ 11: 1 bit Boolean type arrays
-        i1←{⍵,-⍵}⍳120                                 ⍝ 83: 8 bits signed integer
-        i2←{⍵,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
-        i3←{⍵,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
-        dbl←{⍵,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
+        i1←{⍵,0,-⍵}⍳120                                 ⍝ 83: 8 bits signed integer
+        i2←{⍵,0,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
+        i3←{⍵,0,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
+        dbl←{⍵,0,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
         ⍝ Hdbl is 645 but higher order
         Hdbl←{⍵,-⍵}1E14+(2×⍳50)
         ⍝ Hfl is 1287 but higher order
         ⎕FR←fr_decf                                   ⍝ use ⎕FR=1287
-        fl←{⍵,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
+        fl←{⍵,0,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
         Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
         ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
-        cmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
+        cmplx←{(-⍵),⍵,0,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
         Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E14J1E14×⍳20)     ⍝ 1289 but higher order
 
         r←⍬
@@ -63,14 +63,13 @@
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
             :For fr :In 2 1
                 ⎕FR←fr⊃fr_dbl fr_decf
-
+                
+                ⍝ Tests added to achieve complete code coverage
                 case←'independant'
                 case2←⍬
                 desc←testDesc⍬
-                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11                     ⍝ Separate case for larg=0
-                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) (¯1) 11                 ⍝ Separate case for larg=¯1
-                r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1             ⍝ Separate case for larg=0J0
-                r,← 'Ti4' desc RunVariations ((,0, 1E10) genResidue 10) (,0 1E10) (10)  ⍝ Separate case for larg=0.0
+                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11        ⍝ Special optimization for scalar 0 from iresidue at apl/allos/src/scalarscalar.cpp#L518
+                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) ¯1 11      ⍝ Special optimization for scalar ¯1 from iresidue at apl/allos/src/scalarscalar.cpp#L518
 
                 ⍝ Using scan to target specific cases
                 r,← 'Ti5' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
@@ -102,6 +101,17 @@
                     d2←data[?≢(data~d1)]
                     r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
                     r,← 'T3' desc RunVariations ((0,1↓data) genResidue data) (0,1↓data) (data) 
+
+                    ⍝ :If (⎕DR data)∊83 163 323
+                    ⍝     halfLen←(≢data)÷2
+                    ⍝     r,← 'TSeq1' desc RunVariations ({⍵,(1↓⌽⍵),0}halfLen⍴1 2 3 0) 4 data ⍝ Sequences to test functionality of residue
+                    ⍝     r,← 'TSeq2' desc RunVariations ({⍵,(1↓⌽⍵),0}halfLen⍴(⍳9),0) 10 data ⍝ Sequences to test functionality of residue
+                    ⍝ :EndIf
+
+                    ⍝ :If (⎕DR data)∊645
+                    ⍝ halfLen←(≢data)÷2
+                    ⍝     ⍝ r,← 'TSeq1' desc RunVariations ({⍵,(1↓⌽⍵),0}halfLen⍴1.5 2.5 3.5 0.5) 4 data ⍝ Sequences to test functionality of residue
+                    ⍝ :EndIf
 
                     ⍝ tests with comparision tolerance
                     :If ct ⍝ tolerant

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -41,17 +41,15 @@
         i2←{⍵,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
         i3←{⍵,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
         dbl←{⍵,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
-        ⍝ Hdbl and Sdbl is 645 but higher order and lower order
+        ⍝ Hdbl is 645 but higher order
         Hdbl←{⍵,-⍵}1E14+(2×⍳50)
-        Sdbl←{⍵,-⍵}(⍳10)×1E¯40
-        ⍝ Hfl and Sfl is 1287 but higher order and lower order
+        ⍝ Hfl is 1287 but higher order
         ⎕FR←fr_decf                                   ⍝ use ⎕FR=1287
         fl←{⍵,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
         Hfl←{⍵,-⍵}2E29+(1E16×⍳10)
-        Sfl←{⍵,-⍵}(⍳10)×1E¯40
         ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
         cmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
-        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E13J1E13×⍳20)     ⍝ 1289 but higher order
+        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E14J1E14×⍳20)     ⍝ 1289 but higher order
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
@@ -76,11 +74,14 @@
                 r,← 'Ti5' desc RunVariations (1J1 genResidue 11) (1J1) (11)
                 r,←'Ti6' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
                 r,←'Ti7' desc Assert (2/0)≡(2|2/1E40)
+                ⍝ r,←'Ti8' desc Assert (⍬)≡(⍬|11)
+                ⍝ r,←'Ti9' desc Assert (,⍬)≡,(''|11)
+                ⍝ r,←'tb3' desc Assert (1)≡((∧/1 0 1 0)|(∧/1 1 1 1))
 
-                :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl' 'cmplx' 'Hcmplx' 
+                :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
                     ⍝ Cross type tests
-                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl' 'cmplx' 'Hcmplx'
+                    :For case2 :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx'
                         data2←⍎case2
                         desc←testDesc⍬
                         :If (data≡data2)
@@ -97,21 +98,21 @@
                     r,←'T1' desc RunVariations (data genResidue ⌽data) data (⌽data) ⍝ custom func finds results on array
                     ⍝ r,←'T2' desc RunVariations (0⍨¨data) data data ⍝ all are perfectly divisible
                     d1←data[?≢data]
-                    d2←data[?≢data]
+                    d2←data[?≢(data~d1)]
                     r,←'T3' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
 
                     ⍝ tests with comparision tolerance
-                    ⍝ :If ct ⍝ tolerant
-                    ⍝     :If (⊂data)∊Hdbl Hfl Hcmplx
-                    ⍝         ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
-                    ⍝         r,← 'CTDefault' desc Assert ((1≡(d1|d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
-                    ⍝     :EndIf
-                    ⍝ :Else  ⍝ exact
-                    ⍝     :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
-                    ⍝         ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
-                    ⍝         r,← 'CTZero' desc Assert ((0≡(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
-                    ⍝     :EndIf
-                    ⍝ :EndIf
+                    :If ct ⍝ tolerant
+                        :If (⊂data)∊Hdbl Hfl Hcmplx
+                            ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
+                            r,← 'CTDefault' desc Assert ((0≡(d1|d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
+                        :EndIf
+                    :Else  ⍝ exact
+                        :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
+                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
+                            r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
+                        :EndIf
+                    :EndIf
                 :EndFor
             :EndFor
         :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -41,15 +41,15 @@
         i2←{⍵,0,-⍵}10000+⍳1000                          ⍝ 163: 16 bits signed integer
         i3←{⍵,0,-⍵}100000+⍳100                          ⍝ 323: 32 bits signed  integer
         dbl←{⍵,0,-⍵}1000.5+⍳100                         ⍝ 645: 64 bits Floating
-        ⍝ Hdbl is 645 but higher order
+        ⍝ Hdbl is 645 but larger numbers
         Hdbl←{⍵,-⍵}1E14+(2×⍳50)
-        ⍝ Hfl is 1287 but higher order
+        ⍝ Hfl is 1287 but larger numbers
         ⎕FR←fr_decf                                     ⍝ use ⎕FR=1287
         fl←{⍵,0,-⍵}1000.5+⍳100                          ⍝ 1287: 128 bits Decimal
-        Hfl←{⍵,-⍵}2E29+(1E16×⍳10)                       ⍝ 1287 but higher order
+        Hfl←{⍵,-⍵}2E29+(1E16×⍳10)                       ⍝ 1287 but larger numbers
         ⎕FR←fr_dbl                                      ⍝ revert ⎕FR=645
         cmplx←{(-⍵),⍵,0,(+⍵),(-+⍵)}(0J1×⍳100)+⌽⍳100     ⍝ 1289: 128 bits Complex
-        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E14J1E14×⍳20)       ⍝ 1289 but higher order
+        Hcmplx←{(-⍵),⍵,(+⍵),(-+⍵)}(1E14J1E14×⍳20)       ⍝ 1289 but larger numbers
 
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -113,7 +113,7 @@
                     :EndIf
 
                     ⍝ tests with comparision tolerance
-                    almostd1←d1×+/10⍴0.1 ⍝ Almost, but not exactly d1
+                    almostd1←{fr=1:⍵×+/10⍴0.1⋄⍵×1-1E¯30}d1 ⍝ Almost, but not exactly d1
                     :If ct ⍝ tolerant
                         :If (⊂data)∊Hdbl Hfl Hcmplx
                             ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
@@ -127,18 +127,10 @@
                             d1←{(⍵≡¯1)∨(⍵≡0)∨(⍵≡1):data[?≢data]⋄⍵}d1
 
                             ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
-                            r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))                      ⍝ not in the tollerant range
+                            r,← 'CTZero' desc Assert ((0≢(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))                                          ⍝ not in the tollerant range
 
-                            :If fr=2
-                                fltalmostd1←d1×1-1E¯30 ⍝ infinitesimally close to d1
-                                r,← 'CTZeroFltAlmost1' desc Assert (0≡⌊|fltalmostd1|d1) ∨ (1289≡⎕dr data)       ⍝ in the tollerant range
-                                r,← 'CTZeroFltAlmost2' desc Assert ((⌈|d1)≡⌈|d1|fltalmostd1) ∨ (1289≡⎕dr data)
-                                r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (1289≡⎕dr data)             ⍝ not in the tollerant range
-                                r,← 'CTZeroAlmost2' desc Assert (0≡⌈|d1|almostd1) ∨ (1289≡⎕dr data)
-                            :Else
-                                r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ case≡'Hfl'                  ⍝ in the tollerant range
-                                r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨  case≡'Hfl'
-                            :EndIf
+                            r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨  (fr=1 ∧ case≡'Hfl')                                ⍝ in the tollerant range
+                            r,← 'CTZeroAlmost2' desc Assert ((⌈|d1)≡⌈|d1|almostd1) ∨  (fr=1 ∧ case≡'Hfl') ∨ (fr=2 ∧ 1289≡⎕dr data)
                         :EndIf
                     :EndIf
                 :EndFor

--- a/tests/test_residue.apln
+++ b/tests/test_residue.apln
@@ -53,6 +53,17 @@
             :For fr :In 2 1
                 ⎕FR←fr⊃fr_dbl fr_decf
 
+                case←'independant'
+                case2←⍬
+                desc←testDesc⍬
+                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11
+                r,← 'Ti2' desc RunVariations (-1 genResidue 11) (-1) 11
+                r,← 'Ti3' desc RunVariations (0J0 genResidue 1J1) (0J0) 1J1
+                ⍝ r,← 'Ti4' desc RunVariations ((,0.0) genResidue 11) (,0.0) (11)
+                r,← 'Ti5' desc RunVariations (1J1 genResidue 11) (1J1) (11)
+                r,←'Ti6' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)
+                r,←'Ti7' desc Assert (2/0)≡(2|2/1E40)
+
                 :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'Sdbl' 'fl' 'Hfl' 'Sfl' 'cmplx' 'Hcmplx' 
                     data←⍎case
                     ⍝ Cross type tests
@@ -75,25 +86,22 @@
                     d1←data[?≢data]
                     d2←data[?≢data]
                     r,←'T3' desc RunVariations (d1 genResidue d2) d1 d2 ⍝ custom func finds results on single element
+
                     ⍝ tests with comparision tolerance
-                    :If ct ⍝ tolerant
-                        :If (⊂data)∊Hdbl Hfl Hcmplx
-                            ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
-                            r,← 'CTDefault' desc Assert ((1≡(d1∊d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
-                        :EndIf
-                    :Else  ⍝ exact
-                        :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
-                            ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
-                            r,← 'CTZero' desc Assert ((0≡(d1∊d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
-                        :EndIf
-                    :EndIf
+                    ⍝ :If ct ⍝ tolerant
+                    ⍝     :If (⊂data)∊Hdbl Hfl Hcmplx
+                    ⍝         ⍝ Hdbl=Hdbl+1 with default CT, but not for DECF (similar for Hcmplx)
+                    ⍝         r,← 'CTDefault' desc Assert ((1≡(d1|d1+1)) ∨ (fr=2 ∧ (case≡'Hdbl') ∨ (case≡'Hcmplx')))
+                    ⍝     :EndIf
+                    ⍝ :Else  ⍝ exact
+                    ⍝     :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped
+                    ⍝         ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
+                    ⍝         r,← 'CTZero' desc Assert ((0≡(d1|d1+1)) ∨ (fr=1 ∧ case≡'Hfl'))
+                    ⍝     :EndIf
+                    ⍝ :EndIf
                 :EndFor
             :EndFor
         :EndFor
-        case←⍬
-        case2←⍬
-        desc←testDesc⍬
-        r,← 'TB1' desc RunVariations (5 genResidue 11) 5 11
     ∇
 
 :EndNamespace


### PR DESCRIPTION
Residue is a dyadic scalar function which gives the remainder of division between two real numbers. It takes the divisor as the left argument, and the dividend as the right argument.

Also valid for complex numbers