### PR TITLE
Ensure modelSort functions are not idioms 

### DIFF
--- a/tests/behind.apln
+++ b/tests/behind.apln
@@ -115,8 +115,8 @@
       sortAsc←⊂⍤⍋⍛⌷
       sortDesc←⊂⍤⍒⍛⌷
      
-      modelSortAsc←{(⊂⍋⍵)⌷⍵}
-      modelSortDesc←{(⊂⍒⍵)⌷⍵}
+      modelSortAsc←{(⊢⊂⍋⍵)⌷⍵}
+      modelSortDesc←{(⊢⊂⍒⍵)⌷⍵}
      
       ⍝ data
       case←⍬


### PR DESCRIPTION
## Related Issue(s)
- Fixes #140

## Description
Correct the modelSort functions to not use the idiom based sort functions.

## PR Checklist 
- [x] This PR ammends tests for a new primitive
