### PR TITLE
Improve runvariations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 aplcore
+notes/

--- a/docs/how-to-add-tests.md
+++ b/docs/how-to-add-tests.md
@@ -147,7 +147,7 @@ RunVariations is an operator described in [testfns.apln](../testfns.apln). It co
 - **Empty**: empty array of the same type
 - **RandomHighRank**: reshapes to a random shape of up to 4 dimensions
 - **RandomEmptyHighRank**: same as above but with at least one 0 in the shape
-- **RandModelTest**: generates random data matching the datatype and bounds (covers full datatype range over repeated runs)
+- **RandomData**: generates random data matching the datatype and bounds (covers full datatype range over repeated runs)
 - **Shuffle**: randomly reorders elements along the first axis
 - **Intertwine**: creates perfectly alternating duplicates (`data intertwine data`)
 - **Len1/Len10/Len100/Len1000**: cyclic reshape to test different array sizes (triggers different code paths for vectorization, hash tables, etc.)

--- a/docs/how-to-add-tests.md
+++ b/docs/how-to-add-tests.md
@@ -138,14 +138,26 @@ Assert is a function described in [`./unittest.apln`](../unittest.apln) that tak
 
 #### `RunVariations`
 
-RunVariations is a function described in [testfns.apln](../testfns.apln) which takes the expressions to be evaluated and does the following:
-- tests using the standard form it comes in
-- tests a scalar element from the data it gets
-- tests an empty array derived from the input
-- applies a different shape to the input and evaluates
-- creates a different shape that has a 0 in the shape of the input
-- tests the input with the model function to double check the result
-- RandModelTest takes the datatype and the boundary values of the expressions and generates a random array of the same datatype to increase the amount of data we have.
+RunVariations is an operator described in [testfns.apln](../testfns.apln). It comes in two forms: `_RunVariations_` (legacy — compares against a pre-computed expected result; used by add, subtract, multiply, divide, floor, magnitude, residue) and `_RunVariationsWithModel_` (preferred — compares the primitive against a model function, including error behavior).
+
+`_RunVariationsWithModel_` runs the following variations on each call:
+
+- **Base**: tests using the input as-is
+- **RandomScalar**: picks a random item from the data
+- **Empty**: empty array of the same type
+- **RandomHighRank**: reshapes to a random shape of up to 4 dimensions
+- **RandomEmptyHighRank**: same as above but with at least one 0 in the shape
+- **RandModelTest**: generates random data matching the datatype and bounds (covers full datatype range over repeated runs)
+- **Shuffle**: randomly reorders elements along the first axis
+- **Intertwine**: creates perfectly alternating duplicates (`data intertwine data`)
+- **Len1/Len10/Len100/Len1000**: cyclic reshape to test different array sizes (triggers different code paths for vectorization, hash tables, etc.)
+- **Tall1x11/Tall10x11/Tall100x11**: tall matrices with 11 columns
+- **Wide11x1/Wide11x10/Wide11x100**: wide matrices with 11 rows
+- **Square1x1/Square4x4/Square16x16**: square matrices
+
+Setting the `DYALOG_QA_SLOW_TESTS=1` environment variable enables additional slow variations: `Len10000`, `Tall500x11`, `Wide11x500`.
+
+New tests should use `_RunVariationsWithModel_`. The legacy `_RunVariations_` is kept only for tests that haven't been migrated yet.
 
 #### Model function
 

--- a/testfns.apln
+++ b/testfns.apln
@@ -162,12 +162,6 @@
       ⍝ Intertwine test: create perfectly alternating duplicates
       {⍵ #.utils.intertwine ⍵}ChkEqual'Intertwine'
 
-      ⍝ Note: Hash testing (1500⌶) is NOT included here because it adds metadata
-      ⍝ (a pre-computed hash table) that the primitive may use but the model may not,
-      ⍝ causing false positives. Hash tests should be added manually in individual
-      ⍝ test files where the operation is known to work with pre-hashed data
-      ⍝ (e.g. set operations: ∪ ∩ ∊ ⍳ ≠).
-
       ⍝ Length variations: different array sizes trigger different code paths
       ⍝ (vectorization thresholds, hash table creation, etc.)
       :For len :In 1 10 100

--- a/testfns.apln
+++ b/testfns.apln
@@ -74,8 +74,7 @@
           :If val=2
               nlarg←#.random.VariationOf larg
           :EndIf
-     
-     
+
           :If val=2
               actualR←nlarg(op runOrErr)nrarg
               expectedR←nlarg(model runOrErr)nrarg
@@ -83,7 +82,7 @@
               actualR←(op runOrErr)nrarg
               expectedR←(model runOrErr)nrarg
           :EndIf
-          tRes,←('RandModelTest',tID)tCmt Assert expectedR≡actualR
+          tRes,←('RandomData',tID)tCmt Assert expectedR≡actualR
       :EndIf
     ∇
 
@@ -140,10 +139,10 @@
       ⍝ The purpose of this test is to use the entire range of the datatype so a dataset
       ⍝ is generated in the longer run to test more data.
      
-      #.random.VariationOf ChkEqual'RandModelTest'
+      #.random.VariationOf ChkEqual'RandomData'
 
       ⍝ Shuffle test: randomly reorder elements along first axis
-      {1≥≢⍵:⍵ ⋄ (⊂?⍨≢⍵)⌷⍵}ChkEqual'Shuffle'
+      #.utils.shuffle ChkEqual'Shuffle'
 
       ⍝ Intertwine test: create perfectly alternating duplicates
       {⍵ #.utils.intertwine ⍵}ChkEqual'Intertwine'

--- a/testfns.apln
+++ b/testfns.apln
@@ -104,7 +104,7 @@
     ⍝ Run Variations of each test with normal, empty and multiple shaped data.
     ⍝ This operator is similar to _RunVariations_, but runs the model function and compares
     ⍝ the produced result/error messages with the primitive.
-    ∇ {tRes}←spec(rawModel _RunVariationsWithModel_ rawOp)args;ChkEqual;Eval;quadparams;shape;tCmt;tID;⎕CT;⎕DCT;⎕DIV;⎕FR;⎕IO
+    ∇ {tRes}←spec(rawModel _RunVariationsWithModel_ rawOp)args;ChkEqual;Eval;cols;len;quadparams;rows;shape;sq;tCmt;tID;⎕CT;⎕DCT;⎕DIV;⎕FR;⎕IO
       tRes←⍬
       (tID tCmt quadparams)←spec
       ⎕CT ⎕DCT ⎕FR ⎕IO ⎕DIV←quadparams
@@ -155,16 +155,55 @@
       ⍝ is generated in the longer run to test more data.
      
       #.random.VariationOf ChkEqual'RandModelTest'
-     
-        ⍝ todo:
-        ⍝ new variations needs more tests of:
-        ⍝ lengths of arrays from 1 to 10000
-        ⍝ and
-        ⍝ of kind
-        ⍝ scalar
-        ⍝ vector
-        ⍝ tall matrix, 11-column matrix with 10*0 1 2 4 rows
-        ⍝ wide matrix, 11-row matrix with 10*0 1 2 4 columns
-        ⍝ square matrix with ⌈10*0 1 2 4×0.6 (1 4 16 252) rows/columns
+
+      ⍝ Shuffle test: randomly reorder elements along first axis
+      {1≥≢⍵:⍵ ⋄ (⊂?⍨≢⍵)⌷⍵}ChkEqual'Shuffle'
+
+      ⍝ Intertwine test: create perfectly alternating duplicates
+      {⍵ #.utils.intertwine ⍵}ChkEqual'Intertwine'
+
+      ⍝ Hash test: pre-hash arrays with 1500⌶
+      ⍝ The model ignores hash metadata; the primitive uses it.
+      ⍝ Wrapped in :Trap because 1500⌶ may not support all data types.
+      :Trap 0
+          #.utils.hashArray ChkEqual'Hash'
+      :EndTrap
+
+      ⍝ Hash + Intertwine: pre-hash intertwined data
+      :Trap 0
+          {#.utils.hashArray ⍵ #.utils.intertwine ⍵}ChkEqual'HashIntertwine'
+      :EndTrap
+
+      ⍝ Length variations: different array sizes trigger different code paths
+      ⍝ (vectorization thresholds, hash table creation, etc.)
+      :For len :In 1 10 100
+          {len⍴⍵}ChkEqual('Len',⍕len)
+      :EndFor
+
+      ⍝ Tall matrix: 11-column matrix with varying rows (10*0 1 2)
+      :For rows :In 1 10 100
+          {(rows 11)⍴⍵}ChkEqual('Tall',(⍕rows),'x11')
+      :EndFor
+
+      ⍝ Wide matrix: 11-row matrix with varying columns (10*0 1 2)
+      :For cols :In 1 10 100
+          {(11 cols)⍴⍵}ChkEqual('Wide11x',⍕cols)
+      :EndFor
+
+      ⍝ Square matrix: ⌈10*0 1 2×0.6 → 1 4 16
+      :For sq :In 1 4 16
+          {(sq sq)⍴⍵}ChkEqual('Square',(⍕sq),'x',⍕sq)
+      :EndFor
+
+      ⍝ Slow variations (gated behind DYALOG_QA_SLOW_TESTS)
+      :If #.utils.doSlowTests
+          :For len :In 1000 10000
+              {len⍴⍵}ChkEqual('Len',⍕len)
+          :EndFor
+          ⍝ Tall 10*4, wide 10*4, square ⌈10*4×0.6=252
+          {(10000 11)⍴⍵}ChkEqual'Tall10000x11'
+          {(11 10000)⍴⍵}ChkEqual'Wide11x10000'
+          {(252 252)⍴⍵}ChkEqual'Square252x252'
+      :EndIf
     ∇
 :EndNamespace

--- a/testfns.apln
+++ b/testfns.apln
@@ -162,17 +162,11 @@
       ⍝ Intertwine test: create perfectly alternating duplicates
       {⍵ #.utils.intertwine ⍵}ChkEqual'Intertwine'
 
-      ⍝ Hash test: pre-hash arrays with 1500⌶
-      ⍝ The model ignores hash metadata; the primitive uses it.
-      ⍝ Wrapped in :Trap because 1500⌶ may not support all data types.
-      :Trap 0
-          #.utils.hashArray ChkEqual'Hash'
-      :EndTrap
-
-      ⍝ Hash + Intertwine: pre-hash intertwined data
-      :Trap 0
-          {#.utils.hashArray ⍵ #.utils.intertwine ⍵}ChkEqual'HashIntertwine'
-      :EndTrap
+      ⍝ Note: Hash testing (1500⌶) is NOT included here because it adds metadata
+      ⍝ (a pre-computed hash table) that the primitive may use but the model may not,
+      ⍝ causing false positives. Hash tests should be added manually in individual
+      ⍝ test files where the operation is known to work with pre-hashed data
+      ⍝ (e.g. set operations: ∪ ∩ ∊ ⍳ ≠).
 
       ⍝ Length variations: different array sizes trigger different code paths
       ⍝ (vectorization thresholds, hash table creation, etc.)

--- a/testfns.apln
+++ b/testfns.apln
@@ -164,16 +164,16 @@
 
       ⍝ Length variations: different array sizes trigger different code paths
       ⍝ (vectorization thresholds, hash table creation, etc.)
-      :For len :In 1 10 100
+      :For len :In 1 10 100 1000
           {len⍴⍵}ChkEqual('Len',⍕len)
       :EndFor
 
-      ⍝ Tall matrix: 11-column matrix with varying rows (10*0 1 2)
+      ⍝ Tall matrix: 11-column matrix with varying rows (10*0 1 2 3)
       :For rows :In 1 10 100
           {(rows 11)⍴⍵}ChkEqual('Tall',(⍕rows),'x11')
       :EndFor
 
-      ⍝ Wide matrix: 11-row matrix with varying columns (10*0 1 2)
+      ⍝ Wide matrix: 11-row matrix with varying columns (10*0 1 2 3)
       :For cols :In 1 10 100
           {(11 cols)⍴⍵}ChkEqual('Wide11x',⍕cols)
       :EndFor
@@ -185,13 +185,9 @@
 
       ⍝ Slow variations (gated behind DYALOG_QA_SLOW_TESTS)
       :If #.utils.doSlowTests
-          :For len :In 1000 10000
-              {len⍴⍵}ChkEqual('Len',⍕len)
-          :EndFor
-          ⍝ Tall 10*4, wide 10*4, square ⌈10*4×0.6=252
-          {(10000 11)⍴⍵}ChkEqual'Tall10000x11'
-          {(11 10000)⍴⍵}ChkEqual'Wide11x10000'
-          {(252 252)⍴⍵}ChkEqual'Square252x252'
+          {10000⍴⍵}ChkEqual'Len10000'
+          {(500 11)⍴⍵}ChkEqual'Tall500x11'
+          {(11 500)⍴⍵}ChkEqual'Wide11x500'
       :EndIf
     ∇
 :EndNamespace

--- a/testfns.apln
+++ b/testfns.apln
@@ -13,12 +13,9 @@
     ⍝ in _RunVariations_ to skip part of the test for certain primitives.
     isCurrentlyRunning←{∨/⊃,/{∨/⍵⍷↑#.unittest.tests}¨⍵}
 
-    ⍝ tests that don't use this are:
-    ⍝ use a different runvariations:
-    ⍝ - unique
-    ⍝ - uniquemask
-    ⍝ - indexof
-    ⍝ - membership
+    ⍝ Legacy operator. New tests should use _RunVariationsWithModel_ below,
+    ⍝ which compares the primitive against a model function (including error
+    ⍝ behavior) instead of a pre-computed expected result.
 
     ⍝ Run Variations of each test with normal, empty and multiple shaped data
     ∇ {tRes}←tData(model _RunVariations_ op)exp;actualR;actualRE;actualRS;actualRSW0;expectedR;larg;nlarg;nrarg;randr;rarg;shape;shapeW0;skipRandom;tCmt;tID;trimmedrarg;val;⎕CT;⎕DCT;⎕DIV;⎕FR;⎕IO
@@ -88,17 +85,6 @@
           :EndIf
           tRes,←('RandModelTest',tID)tCmt Assert expectedR≡actualR
       :EndIf
-     
-        ⍝ todo:
-        ⍝ new variations needs more tests of:
-        ⍝ lengths of arrays from 1 to 10000
-        ⍝ and
-        ⍝ of kind
-        ⍝ scalar
-        ⍝ vector
-        ⍝ tall matrix, 11-column matrix with 10*0 1 2 4 rows
-        ⍝ wide matrix, 11-row matrix with 10*0 1 2 4 columns
-        ⍝ square matrix with ⌈10*0 1 2 4×0.6 (1 4 16 252) rows/columns
     ∇
 
     ⍝ Run Variations of each test with normal, empty and multiple shaped data.

--- a/tests/behind.apln
+++ b/tests/behind.apln
@@ -4,7 +4,6 @@
     Ints←#.random.Ints
     Chars←#.random.Chars
     shuffle←#.utils.shuffle
-    intertwine←#.utils.intertwine
 
       model←{
           ⍺←⍵
@@ -177,20 +176,18 @@
                   :For case :In caselist
                       data←⍎case
                       desc←testDesc
-                      r,←('TGen1: ',order⊃'Asc' 'Desc')desc Assert(≢model⊃shuffle data)≡≢(sort⊃shuffle data) ⍝ length of result does not change
-     
-                      r,←('T1: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂data ⍝ no shuffle
-                      r,←('T2: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂shuffle data ⍝ shuffle data
-                      r,←('T3: ',order⊃'Asc' 'Desc')desc Assert(model⊃shuffle data)≡(sort⊃shuffle data) ⍝ different shuffles produce same result
+                      :If 1<≢data ⍝ skip scalars: ⍋ requires rank ≥ 1
+                          r,←('TGen1: ',order⊃'Asc' 'Desc')desc Assert(≢model shuffle data)≡≢(sort shuffle data) ⍝ length of result does not change
+                      :EndIf
+
+                      r,←('T1: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂data
      
      
                       :For case2 :In caselist
                           data2←⍎case2
                           desc←testDesc
      
-                          r,←('T3: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂data,data2 ⍝ no shuffle
-                          r,←('T4: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂data intertwine data2 ⍝ intertwine data with data2
-                          r,←('T5: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂shuffle data,data2 ⍝ shuffle data and data2
+                          r,←('T2: ',order⊃'Asc' 'Desc')desc quadparams RunVariations⊂data,data2
                       :EndFor
                   :EndFor
               :EndFor

--- a/tests/union_and_intersection.apln
+++ b/tests/union_and_intersection.apln
@@ -1,7 +1,6 @@
 :Namespace union_and_intersection
     Assert←#.unittest.Assert
     ints←#.utils.ints
-    doSlowTests←#.utils.doSlowTests
 
     ⍝ Models are not in use but kept for reference
     ⍝ model←{⍺,(∧/⍺≢¨⍵)/⍵}
@@ -104,14 +103,7 @@
                           r,←({⍵≡'∪':'Union (∪) Cross2' ⋄ 'Intersection (∩) Cross2'}op)desc quadparams RunVariations(data,data)data2
                           r,←({⍵≡'∪':'Union (∪) Cross3' ⋄ 'Intersection (∩) Cross3'}op)desc quadparams RunVariations data(data2,data2)
                           r,←({⍵≡'∪':'Union (∪) Cross4' ⋄ 'Intersection (∩) Cross4'}op)desc quadparams RunVariations(data,data)(data2,data2)
-     
-                          :For len :In 1 10 100 1000 10000
-                              :If (~doSlowTests)∧(len≡10000)
-                                  :Continue ⍝ Skip one case because it takes 30 minutes with len 10000
-                              :EndIf
-                              r,←({⍵≡'∪':'Union (∪) Cross5' ⋄ 'Intersection (∩) Cross5'}op)desc quadparams RunVariations((?len)⍴data,data2)((?len)⍴data2,data)
-                          :EndFor
-     
+
                           r,←({⍵≡'∪':'Union (∪) Hash2' ⋄ 'Intersection (∩) Hash2'}op)desc quadparams RunVariations(data,data)(#.utils.hashArray data2,data2)
      
                           ⍝ General tests to test the basic rules of union

--- a/tests/unique.apln
+++ b/tests/unique.apln
@@ -43,7 +43,7 @@
       tRes,←('ShapeW0',tID)tCmt Assert expectedRSW0≡actualRSW0
     ∇
 
-    ∇ {r}←test_unique;ct_default;dct_default;fr_dbl;fr_decf;bool;i1;char0;char1;char2;i2;char3;i3;ptr;dbl;Hdbl;Sdbl;cmplx;Hcmplx;fl;Hfl;⎕FR;⎕CT;⎕DCT;testDesc;case;case2;desc;ct;fr;data;data2;shuffledData;repetitions;shuffledRepeatedData;d1;almostd1S;almostd1B;d;u;s;x
+    ∇ {r}←test_unique;ct_default;dct_default;fr_dbl;fr_decf;bool;i1;char0;char1;char2;i2;char3;i3;ptr;dbl;Hdbl;Sdbl;cmplx;Hcmplx;fl;Hfl;⎕FR;⎕CT;⎕DCT;testDesc;case;case2;desc;ct;fr;data;data2;repetitions;shuffledRepeatedData;d1;almostd1S;almostd1B;d;u;s;x
       ct_default←#.utils.ct_default
       dct_default←#.utils.dct_default
       fr_dbl←#.utils.fr_dbl
@@ -145,11 +145,8 @@
                   r,←'T3'desc RunVariations data(data intertwine data)             ⍝ all elements are perfectly intertwined
                   r,←'T4'desc RunVariations data(hashArray data intertwine data)   ⍝ using a pre-hashed array on intertwined data
      
-                  shuffledData←↑shuffle data
-                  r,←'T5'desc RunVariations(model shuffledData)shuffledData   ⍝ shuffle data without creating duplicate data
-     
                   repetitions←?6
-                  shuffledRepeatedData←↑shuffle repetitions/data
+                  shuffledRepeatedData←shuffle repetitions/data
                   r,←'T6'desc RunVariations(model shuffledRepeatedData)shuffledRepeatedData  ⍝ duplicate and shuffle
      
                     ⍝ tests with comparison tolerance

--- a/tests/uniquemask.apln
+++ b/tests/uniquemask.apln
@@ -50,7 +50,7 @@
       tRes,←('ShapeW0',tID)tCmt Assert expectedRSW0≡actualRSW0
     ∇
 
-    ∇ {r}←test_uniquemask;ct_default;dct_default;fr_dbl;fr_decf;bool;i1;char0;char1;char2;i2;char3;i3;ptr;dbl;cmplx;Hcmplx;Hdbl;Sdbl;⎕FR;fl;Hfl;testDesc;case;case2;desc;ct;⎕CT;⎕DCT;fr;u;s;x;data;data2;shuffledData;repetitions;shuffledRepeatedData;d1;almostd1S;almostd1B;d
+    ∇ {r}←test_uniquemask;ct_default;dct_default;fr_dbl;fr_decf;bool;i1;char0;char1;char2;i2;char3;i3;ptr;dbl;cmplx;Hcmplx;Hdbl;Sdbl;⎕FR;fl;Hfl;testDesc;case;case2;desc;ct;⎕CT;⎕DCT;fr;u;s;x;data;data2;repetitions;shuffledRepeatedData;d1;almostd1S;almostd1B;d
       ct_default←#.utils.ct_default
       dct_default←#.utils.dct_default
       fr_dbl←#.utils.fr_dbl
@@ -149,11 +149,8 @@
                   r,←'T3'desc RunVariations((1⍨¨data)intertwine(0⍨¨data))(data intertwine data)             ⍝ all elements are perfectly intertwined
                   r,←'T4'desc RunVariations((1⍨¨data)intertwine(0⍨¨data))(hashArray data intertwine data)   ⍝ using a pre-hashed array on intertwined data
      
-                  shuffledData←↑shuffle data
-                  r,←'T5'desc RunVariations(model shuffledData)shuffledData   ⍝ shuffle data without creating duplicate data
-     
                   repetitions←?6
-                  shuffledRepeatedData←↑shuffle repetitions/data
+                  shuffledRepeatedData←shuffle repetitions/data
                   r,←'T6'desc RunVariations(model shuffledRepeatedData)shuffledRepeatedData  ⍝ duplicate and shuffle
      
                     ⍝ tests with comparison tolerance

--- a/utils.apln
+++ b/utils.apln
@@ -13,7 +13,7 @@
     div_1←1
 
     ⍝ utility functions
-    shuffle←{⊂⍤?⍨∘≢⌷⍵}              ⍝ completely Random shuffle
+    shuffle←{1≥≢⍵:⍵ ⋄ (⊂?⍨≢⍵)⌷⍵}    ⍝ random reorder of ⍵ along first axis
     intertwine←{(⊂⍋∊⍳∘≢¨⍺ ⍵)⌷⍺⍪⍵}   ⍝ perfectly intertwine two arrays
     hashArray←1500⌶                 ⍝ pre-hash array
     stripToSameLen←{(⍺(⌊⍥≢)⍵)↑¨⍺ ⍵} ⍝ get two arrays to the length of the shorter array


### PR DESCRIPTION
## Related Issue(s)

- fixes #87 

## Description

Enhance `_RunVariationsWithModel_` with new test variations to centralize patterns previously duplicated
  across test files.

  Changes

  `testfns.apln` — `_RunVariationsWithModel_` now runs these additional variations on every call:
  - `Shuffle`: random reorder along first axis
  - `Intertwine`: alternating duplicates
  - `Len1/10/100/1000`: cyclic reshape to test different array sizes
  - `Tall/Wide/Square` matrices at small dimensions
  - Slow variants (gated by `DYALOG_QA_SLOW_TESTS`): `Len10000`, `Tall500x11`, `Wide11x500`

  Also labeled `_RunVariations_` as legacy and removed its outdated TODO block.

  `utils.apln` — Fixed shuffle: due to operator binding `{⊂⍤?⍨∘≢⌷⍵}` returned an enclosed permutation vector
  instead of shuffled data. Replaced with `{1≥≢⍵:⍵ ⋄ (⊂?⍨≢⍵)⌷⍵}`.

  Test files — Removed redundant tests now covered by the operator:
  - `union_and_intersection.apln`: removed length variation loop
  - `unique.apln`, `uniquemask.apln`: removed T5 (basic shuffle); kept T6 (shuffle of duplicated data)
  - `behind.apln`: removed inner T5 (basic shuffle of concat) and outer T2/T3, renumbered inner tests, added
   scalar guard to TGen1

  Other:
  - Renamed `RandModelTest` → RandomData for naming consistency
  - Updated `docs/how-to-add-tests.md` with the full variation list and slow-test gate

  Test plan

  - All 18 test suites pass with 0 failures (`unittest.RunTests`)
  - Verified with `DYALOG_QA_SLOW_TESTS` off (default coverage) and on (extended coverage)